### PR TITLE
Handle trade import residuals

### DIFF
--- a/core/trade.py
+++ b/core/trade.py
@@ -51,7 +51,21 @@ class TradeChannel:
             )
         if cost > 0:
             inventory.consume({Resource.GOLD: cost})
-        inventory.add({self.resource: amount})
+        residual = inventory.add({self.resource: amount})
+        leftover = residual.get(self.resource, 0.0)
+        if leftover > 1e-6:
+            refund = leftover * self.price_per_unit
+            if refund > 0:
+                inventory.add({Resource.GOLD: refund})
+            if leftover >= amount - 1e-6:
+                self.mode = "pause"
+                notify(
+                    f"Comercio de {self.resource.value} pausado: almacén sin espacio"
+                )
+            else:
+                notify(
+                    f"Comercio de {self.resource.value}: importación limitada por capacidad"
+                )
 
     def _handle_export(self, amount: float, inventory: Inventory, notify) -> None:
         available = inventory.get_amount(self.resource)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -83,6 +83,23 @@ def test_trade_operations() -> None:
     assert channel.mode == "pause", "Export should pause when stock remains at zero"
 
 
+def test_import_refunds_when_capacity_full() -> None:
+    ui_bridge.init_game()
+    state = get_game_state()
+    state.inventory.set_amount(Resource.HOPS, 0)
+    state.inventory.set_capacity(Resource.HOPS, 0)
+    state.inventory.set_amount(Resource.GOLD, 100)
+
+    gold_before = state.inventory.get_amount(Resource.GOLD)
+
+    ui_bridge.set_trade_mode(Resource.HOPS.value, "import")
+    ui_bridge.set_trade_rate(Resource.HOPS.value, 60)
+    ui_bridge.tick(1.0)
+
+    gold_after = state.inventory.get_amount(Resource.GOLD)
+    assert abs(gold_after - gold_before) <= 1e-6, "Gold should not decrease when import fails"
+
+
 def test_season_rotation() -> None:
     ui_bridge.init_game()
     state = get_game_state()


### PR DESCRIPTION
## Summary
- refund gold when trade imports overflow storage and pause channels when space runs out
- add a backend test covering the no-charge behavior when imports cannot be stored

## Testing
- pytest tests/test_backend.py::test_import_refunds_when_capacity_full

------
https://chatgpt.com/codex/tasks/task_e_68dda56dc56c83328cf447124dd1e775