### PR TITLE
Update README with backend simulation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,42 @@ Abrí <http://127.0.0.1:5000> en tu navegador para ver el panel.
 
 ## Qué incluye
 
-- **Flask mínimo**: una sola ruta (`/`) que renderiza la plantilla principal.
-- **Maquetación Tailwind**: se carga desde CDN, sin build tools adicionales.
-- **Interacción básica**: acordeones, asignación de trabajadores, y ajustes de comercio con estado persistido en `localStorage`.
-- **Assets estáticos**: estilos adicionales, JavaScript y `png` de marcador de posición para los íconos.
+- **Simulación de backend en memoria**: `core.game_state` calcula producción, trabajadores y comercio con un reloj interno para entregar snapshots consistentes.
+- **Puente `api/ui_bridge`**: expone operaciones de tick, construcción, comercio y asignación de trabajadores listas para reutilizarse desde la UI o rutas HTTP.
+- **Persistencia simple**: `core.persistence` ofrece guardado y carga en disco, integrados en el puente para facilitar su consumo desde la interfaz.
+- **Frontend ligero**: Flask sirve la plantilla principal con Tailwind por CDN y JavaScript sin dependencias que invoca las acciones anteriores.
 
 ## Limitaciones
 
-- No hay backend ni simulación económica real; todos los datos son mock en el navegador.
-- Las acciones de construcción/comercio sólo actualizan el estado de la UI.
+- La simulación corre en un solo proceso y no guarda automáticamente; hay que llamar a los helpers de guardado/carga cuando corresponda.
+- Todavía no existen rutas HTTP dedicadas: toda la interacción pasa por el puente en memoria y cualquier API adicional debe implementarse manualmente.
 
 Este proyecto sirve como punto de partida para iterar sobre el diseño de un panel de aldea *idle*.
+
+## Pruebas y API
+
+### Pruebas del backend
+
+Con el entorno virtual activo y las dependencias instaladas, ejecuta:
+
+```bash
+python -m pytest
+```
+
+Para aislar el conjunto básico también puedes correr directamente el módulo de pruebas principal:
+
+```bash
+python tests/test_backend.py
+```
+
+### Integración con futuras rutas HTTP
+
+- Importa las funciones necesarias desde `api.ui_bridge` dentro de las nuevas rutas Flask para reutilizar la simulación existente.
+- Cada función devuelve diccionarios listos para serializar como JSON, lo que simplifica la exposición como endpoints REST.
+- Llama periódicamente a `tick(dt)` (por ejemplo, desde una tarea programada o un endpoint dedicado) para mantener el estado sincronizado antes de responder a los clientes.
+
+## Módulos clave para contribuir
+
+- `core/game_state.py`: núcleo de la simulación y punto central para snapshots hacia la UI.
+- `core/trade.py`: lógica de canales de comercio y reglas de intercambio de recursos.
+- `core/persistence.py`: utilidades de serialización/deserialización para guardar y cargar partidas.


### PR DESCRIPTION
## Summary
- rewrite the feature overview and limitations to cover the backend simulation, UI bridge, and persistence helpers
- add backend testing instructions and guidance for wiring new HTTP routes through the existing bridge
- reference the core simulation modules to help new contributors orient themselves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda5755b68833294c1444b8a7469f5