### PR TITLE
Add JSON API endpoints and wire UI to backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,169 @@
-from flask import Flask, render_template
+"""Flask application exposing the management game UI and JSON API."""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify, render_template, request
+
+from api import ui_bridge
+
 
 app = Flask(__name__)
 
 
 @app.route("/")
-def index():
+def index() -> str:
     """Render the idle village dashboard."""
+
     return render_template("index.html")
+
+
+def _json_response(payload: dict[str, object], *, success_status: int = 200):
+    """Return a payload encoded as JSON with an inferred status code."""
+
+    status = success_status if payload.get("ok", True) else 400
+    return jsonify(payload), status
+
+
+@app.post("/api/init")
+def api_init():
+    """Initialise the game state and return the first UI snapshot."""
+
+    result = ui_bridge.init_game()
+    if not result.get("ok", False):
+        return _json_response(result)
+
+    payload = {
+        "ok": True,
+        "hud": ui_bridge.get_hud_snapshot(),
+        "buildings": ui_bridge.list_buildings_snapshot().get("buildings", []),
+        "jobs": ui_bridge.get_jobs_snapshot(),
+        "trade": ui_bridge.get_trade_snapshot(),
+    }
+    return _json_response(payload)
+
+
+@app.get("/api/hud")
+def api_hud():
+    """Return the latest HUD snapshot."""
+
+    payload = {
+        "ok": True,
+        "hud": ui_bridge.get_hud_snapshot(),
+        "jobs": ui_bridge.get_jobs_snapshot(),
+        "trade": ui_bridge.get_trade_snapshot(),
+    }
+    return _json_response(payload)
+
+
+@app.get("/api/buildings")
+def api_buildings():
+    """Return the current list of buildings along with worker data."""
+
+    payload = {
+        "ok": True,
+        "buildings": ui_bridge.list_buildings_snapshot().get("buildings", []),
+        "jobs": ui_bridge.get_jobs_snapshot(),
+    }
+    return _json_response(payload)
+
+
+@app.get("/api/trade")
+def api_trade():
+    """Return the current trade channel configuration."""
+
+    payload = {"ok": True, "trade": ui_bridge.get_trade_snapshot()}
+    return _json_response(payload)
+
+
+@app.post("/api/actions/build")
+def action_build():
+    """Construct a new building of the provided type."""
+
+    data = request.get_json(silent=True) or {}
+    type_key = data.get("type")
+    if not type_key:
+        return _json_response({"ok": False, "error": "Missing 'type'"})
+    return _json_response(ui_bridge.build_building(str(type_key)))
+
+
+@app.post("/api/actions/demolish")
+def action_demolish():
+    """Demolish a building by id."""
+
+    data = request.get_json(silent=True) or {}
+    building_id = data.get("id")
+    if building_id is None:
+        return _json_response({"ok": False, "error": "Missing 'id'"})
+    return _json_response(ui_bridge.demolish_building(int(building_id)))
+
+
+@app.post("/api/actions/toggle")
+def action_toggle():
+    """Enable or disable a building."""
+
+    data = request.get_json(silent=True) or {}
+    building_id = data.get("id")
+    enabled = data.get("enabled")
+    if building_id is None or enabled is None:
+        return _json_response({"ok": False, "error": "Missing 'id' or 'enabled'"})
+    return _json_response(ui_bridge.toggle_building(int(building_id), bool(enabled)))
+
+
+@app.post("/api/actions/assign")
+def action_assign():
+    """Assign workers to a building (incrementally)."""
+
+    data = request.get_json(silent=True) or {}
+    building_id = data.get("id")
+    workers = data.get("workers")
+    if building_id is None or workers is None:
+        return _json_response({"ok": False, "error": "Missing 'id' or 'workers'"})
+    return _json_response(ui_bridge.assign_workers(int(building_id), int(workers)))
+
+
+@app.post("/api/actions/unassign")
+def action_unassign():
+    """Remove workers from a building (incrementally)."""
+
+    data = request.get_json(silent=True) or {}
+    building_id = data.get("id")
+    workers = data.get("workers")
+    if building_id is None or workers is None:
+        return _json_response({"ok": False, "error": "Missing 'id' or 'workers'"})
+    return _json_response(ui_bridge.unassign_workers(int(building_id), int(workers)))
+
+
+@app.post("/api/actions/trade/mode")
+def action_trade_mode():
+    """Update the mode of a trade channel."""
+
+    data = request.get_json(silent=True) or {}
+    resource_key = data.get("resource")
+    mode = data.get("mode")
+    if not resource_key or mode is None:
+        return _json_response({"ok": False, "error": "Missing 'resource' or 'mode'"})
+    return _json_response(ui_bridge.set_trade_mode(str(resource_key), str(mode)))
+
+
+@app.post("/api/actions/trade/rate")
+def action_trade_rate():
+    """Update the rate of a trade channel."""
+
+    data = request.get_json(silent=True) or {}
+    resource_key = data.get("resource")
+    rate = data.get("rate")
+    if resource_key is None or rate is None:
+        return _json_response({"ok": False, "error": "Missing 'resource' or 'rate'"})
+    return _json_response(ui_bridge.set_trade_rate(str(resource_key), float(rate)))
+
+
+@app.post("/api/actions/tick")
+def action_tick():
+    """Advance the simulation for visual refreshes."""
+
+    data = request.get_json(silent=True) or {}
+    dt = float(data.get("dt", 1.0))
+    return _json_response(ui_bridge.tick(dt))
 
 
 if __name__ == "__main__":

--- a/static/main.js
+++ b/static/main.js
@@ -1,425 +1,589 @@
 (function () {
-  const STORAGE_KEY = "idle-village-state-v1";
-
-  const defaultState = {
-    resources: {
-      happiness: 82,
-      gold: 320,
-      wood: 210,
-      planks: 46,
-      stone: 138,
-      tools: 12,
-      wheat: 75,
-    },
-    population: {
-      total: 20,
-    },
-    buildings: [
-      {
-        id: "woodcutter-camp",
-        name: "Woodcutter Camp",
-        category: "wood",
-        built: 1,
-        active: 1,
-        capacityPerBuilding: 2,
-        icon: "🪓",
-      },
-      {
-        id: "lumber-hut",
-        name: "Lumber Hut",
-        category: "wood",
-        built: 2,
-        active: 4,
-        capacityPerBuilding: 2,
-        icon: "🏚️",
-      },
-      {
-        id: "stone-quarry",
-        name: "Stone Quarry",
-        category: "stone",
-        built: 1,
-        active: 3,
-        capacityPerBuilding: 3,
-        icon: "⛏️",
-      },
-      {
-        id: "wheat-farm",
-        name: "Wheat Farm",
-        category: "crops",
-        built: 0,
-        active: 0,
-        capacityPerBuilding: 2,
-        icon: "🌾",
-      },
-    ],
-    jobs: [
-      { id: "forester", name: "Forester", assigned: 4, max: 6, icon: "🌲" },
-      { id: "miner", name: "Miner", assigned: 3, max: 5, icon: "⛏️" },
-      { id: "farmer", name: "Farmer", assigned: 5, max: 6, icon: "🧑‍🌾" },
-      { id: "artisan", name: "Artisan", assigned: 3, max: 5, icon: "🛠️" },
-    ],
-    trade: [
-      { id: "gold", label: "Gold", export: 8, import: 2, icon: "🪙" },
-      { id: "planks", label: "Planks", export: 4, import: 3, icon: "🪵" },
-      { id: "tools", label: "Tools", export: 2, import: 1, icon: "🛠️" },
-      { id: "wheat", label: "Wheat", export: 5, import: 6, icon: "🌾" },
-    ],
+  const BUILDING_TYPES = {
+    woodcutter_camp: { name: "Woodcutter Camp", icon: "🪓", category: "Forestry" },
+    lumber_hut: { name: "Lumber Hut", icon: "🏚️", category: "Forestry" },
+    stone_quarry: { name: "Stone Quarry", icon: "⛏️", category: "Mining" },
+    wheat_farm: { name: "Wheat Farm", icon: "🌾", category: "Agriculture" },
+    brewery: { name: "Brewery", icon: "🍺", category: "Industry" },
   };
 
-  function clone(value) {
-    return JSON.parse(JSON.stringify(value));
-  }
-
-  function loadState() {
-    try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (!raw) {
-        return clone(defaultState);
-      }
-      const parsed = JSON.parse(raw);
-      return {
-        resources: { ...defaultState.resources, ...parsed.resources },
-        population: { ...defaultState.population, ...parsed.population },
-        buildings: Array.isArray(parsed.buildings) && parsed.buildings.length
-          ? parsed.buildings
-          : clone(defaultState.buildings),
-        jobs: Array.isArray(parsed.jobs) && parsed.jobs.length
-          ? parsed.jobs
-          : clone(defaultState.jobs),
-        trade: Array.isArray(parsed.trade) && parsed.trade.length
-          ? parsed.trade
-          : clone(defaultState.trade),
-      };
-    } catch (error) {
-      console.warn("Idle Village: failed to load state", error);
-      return clone(defaultState);
-    }
-  }
-
-  let state = loadState();
-
-  function saveState() {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    } catch (error) {
-      console.warn("Idle Village: failed to save state", error);
-    }
-  }
-
-  const buildingContainers = {
-    wood: document.querySelector('[data-category="wood"]'),
-    stone: document.querySelector('[data-category="stone"]'),
-    crops: document.querySelector('[data-category="crops"]'),
+  const RESOURCE_INFO = {
+    WOOD: { label: "Wood", icon: "🪵" },
+    STONE: { label: "Stone", icon: "🪨" },
+    GRAIN: { label: "Grain", icon: "🌾" },
+    WATER: { label: "Water", icon: "💧" },
+    GOLD: { label: "Gold", icon: "🪙" },
+    HOPS: { label: "Hops", icon: "🍺" },
   };
+
+  const state = {
+    hud: null,
+    buildings: [],
+    jobs: null,
+    trade: {},
+    initialised: false,
+  };
+
+  const hudChips = document.getElementById("hud-chips");
+  const hudStatus = document.getElementById("hud-status");
+  const hudWarnings = document.getElementById("hud-warnings");
+
+  const buildingList = document.getElementById("building-list");
+  const buildingStatus = document.getElementById("buildings-status");
+  const buildForm = document.getElementById("build-form");
+  const buildSelect = document.getElementById("build-type");
 
   const jobsList = document.getElementById("jobs-list");
+  const jobsStatus = document.getElementById("jobs-status");
+  const jobsCount = document.getElementById("jobs-count");
+  const workersAvailable = document.getElementById("workers-available");
+  const workersAssigned = document.getElementById("workers-assigned");
+
   const tradeList = document.getElementById("trade-list");
-  const jobsCountLabel = document.getElementById("jobs-count");
+  const tradeStatus = document.getElementById("trade-status");
 
-  function getCapacity(building) {
-    return building.built * building.capacityPerBuilding;
+  function setStatus(element, type, message) {
+    if (!element) return;
+    element.classList.remove("loading", "error");
+    if (!type) {
+      element.textContent = "";
+      element.setAttribute("hidden", "hidden");
+      return;
+    }
+    if (type === "loading") {
+      element.classList.add("loading");
+    } else if (type === "error") {
+      element.classList.add("error");
+    }
+    element.textContent = message;
+    element.removeAttribute("hidden");
   }
 
-  function getTotalAssigned() {
-    const buildingWorkers = state.buildings.reduce((total, building) => total + Number(building.active || 0), 0);
-    const jobWorkers = state.jobs.reduce((total, job) => total + Number(job.assigned || 0), 0);
-    return buildingWorkers + jobWorkers;
+  function capitalise(value) {
+    if (typeof value !== "string" || !value.length) return value;
+    return value.charAt(0).toUpperCase() + value.slice(1);
   }
 
-  function updateChips() {
-    const chipElements = document.querySelectorAll(".chip");
-    const assigned = getTotalAssigned();
-    chipElements.forEach((chip) => {
-      const resourceKey = chip.dataset.resource;
-      const valueSpan = chip.querySelector(".value");
-      if (!valueSpan) return;
-      switch (resourceKey) {
-        case "happiness":
-          valueSpan.textContent = `${state.resources.happiness}%`;
-          break;
-        case "population":
-          valueSpan.textContent = `${assigned}/${state.population.total}`;
-          break;
-        default:
-          if (state.resources[resourceKey] !== undefined) {
-            valueSpan.textContent = state.resources[resourceKey];
-          }
-          break;
-      }
+  function formatTime(seconds) {
+    const total = Math.max(0, Number(seconds) || 0);
+    const minutes = Math.floor(total / 60);
+    const secs = Math.floor(total % 60);
+    return `${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+
+  function formatNumber(value) {
+    const num = Number(value) || 0;
+    if (Math.abs(num) >= 100) {
+      return Math.round(num);
+    }
+    return Number(num.toFixed(1));
+  }
+
+  function formatRate(value) {
+    const num = Number(value) || 0;
+    const rounded = Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(2);
+    return `${num > 0 ? "+" : ""}${rounded}`;
+  }
+
+  function statusInfo(code) {
+    const map = {
+      ok: { label: "Active", className: "is-active" },
+      pausado: { label: "Paused", className: "is-paused" },
+      falta_insumos: { label: "No inputs", className: "is-error" },
+      capacidad_llena: { label: "Storage full", className: "is-error" },
+      falta_mantenimiento: { label: "Maintenance", className: "is-error" },
+    };
+    return map[code] || { label: capitalise(code || "Unknown"), className: "" };
+  }
+
+  async function callApi(url, { method = "GET", body } = {}) {
+    const options = {
+      method,
+      headers: { Accept: "application/json" },
+    };
+    if (body !== undefined) {
+      options.body = JSON.stringify(body);
+      options.headers["Content-Type"] = "application/json";
+    }
+    const response = await fetch(url, options);
+    let data;
+    try {
+      data = await response.json();
+    } catch (error) {
+      data = null;
+    }
+    if (!response.ok) {
+      const message = (data && data.error) || response.statusText;
+      throw new Error(message || "Unexpected response");
+    }
+    if (data && data.ok === false) {
+      throw new Error(data.error || "Operation failed");
+    }
+    return data || {};
+  }
+
+  function populateBuildOptions() {
+    if (!buildSelect) return;
+    buildSelect.innerHTML = "";
+    const fragment = document.createDocumentFragment();
+    Object.entries(BUILDING_TYPES).forEach(([value, meta]) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = `${meta.icon} ${meta.name}`;
+      fragment.appendChild(option);
     });
+    buildSelect.appendChild(fragment);
+  }
+
+  function renderWarnings() {
+    if (!hudWarnings) return;
+    hudWarnings.innerHTML = "";
+    const warnings = (state.hud && Array.isArray(state.hud.warnings)) ? state.hud.warnings : [];
+    if (!warnings.length) {
+      const item = document.createElement("li");
+      item.className = "empty";
+      item.textContent = "All systems stable";
+      hudWarnings.appendChild(item);
+      return;
+    }
+    warnings.forEach((warning) => {
+      const item = document.createElement("li");
+      item.textContent = warning;
+      hudWarnings.appendChild(item);
+    });
+  }
+
+  function renderHud() {
+    if (!hudChips) return;
+    if (!state.hud) {
+      hudChips.innerHTML = "";
+      setStatus(hudStatus, "loading", "Loading HUD…");
+      return;
+    }
+    setStatus(hudStatus, null);
+    hudChips.setAttribute("aria-busy", "false");
+    hudChips.innerHTML = "";
+    const chips = [];
+    chips.push({ label: "Season", value: capitalise(state.hud.season || "-") });
+    chips.push({ label: "Time left", value: formatTime(state.hud.time_left) });
+    if (state.jobs) {
+      const used = state.jobs.total_workers - state.jobs.available_workers;
+      chips.push({ label: "Workers", value: `${used}/${state.jobs.total_workers}` });
+    }
+    const resources = Array.isArray(state.hud.resources) ? state.hud.resources : [];
+    resources.forEach((resource) => {
+      const info = RESOURCE_INFO[resource.key] || { label: capitalise(resource.key), icon: "📦" };
+      const amount = formatNumber(resource.amount);
+      const capacity = resource.capacity != null ? formatNumber(resource.capacity) : null;
+      chips.push({
+        label: `${info.icon} ${info.label}`,
+        value: capacity != null ? `${amount}/${capacity}` : `${amount}`,
+      });
+    });
+    const fragment = document.createDocumentFragment();
+    chips.forEach((chip) => {
+      const div = document.createElement("div");
+      div.className = "chip";
+      const label = document.createElement("span");
+      label.textContent = chip.label;
+      const value = document.createElement("span");
+      value.className = "value";
+      value.textContent = chip.value;
+      div.appendChild(label);
+      div.appendChild(value);
+      fragment.appendChild(div);
+    });
+    hudChips.appendChild(fragment);
+    renderWarnings();
+  }
+
+  function formatResourceMap(map) {
+    const entries = Object.entries(map || {});
+    if (!entries.length) {
+      return "—";
+    }
+    return entries
+      .map(([key, value]) => {
+        const info = RESOURCE_INFO[key] || { label: capitalise(key), icon: "📦" };
+        return `${info.icon} ${info.label}: ${formatNumber(value)}`;
+      })
+      .join("  ·  ");
   }
 
   function renderBuildings() {
-    Object.values(buildingContainers).forEach((container) => {
-      if (container) container.innerHTML = "";
-    });
-
+    if (!buildingList) return;
+    buildingList.innerHTML = "";
+    if (!state.initialised) {
+      setStatus(buildingStatus, "loading", "Loading buildings…");
+      return;
+    }
+    if (!Array.isArray(state.buildings) || !state.buildings.length) {
+      setStatus(buildingStatus, null);
+      const empty = document.createElement("li");
+      empty.className = "empty-placeholder";
+      empty.textContent = "No buildings constructed yet. Use the selector above to build one.";
+      buildingList.appendChild(empty);
+      return;
+    }
+    setStatus(buildingStatus, null);
+    const fragment = document.createDocumentFragment();
     state.buildings.forEach((building) => {
-      const container = buildingContainers[building.category];
-      if (!container) return;
-      const capacity = getCapacity(building);
-      const article = document.createElement("li");
-      article.innerHTML = `
-        <article class="building-card" data-building-id="${building.id}">
-          <span class="icon-badge" role="img" aria-label="${building.name} icon">${building.icon}</span>
-          <div class="building-meta">
-            <div class="flex items-start justify-between gap-2">
-              <h3 class="text-base font-semibold text-slate-100">${building.name}</h3>
-              <span class="text-[0.65rem] uppercase tracking-[0.2em] text-slate-500">${building.category}</span>
+      const meta = BUILDING_TYPES[building.type] || { name: building.name, icon: "🏛️", category: capitalise(building.type) };
+      const status = statusInfo(building.status);
+      const listItem = document.createElement("li");
+      listItem.className = "building-card";
+      listItem.dataset.buildingId = String(building.id);
+      listItem.innerHTML = `
+        <article>
+          <header class="building-card__header">
+            <div class="flex items-start gap-3">
+              <span class="icon-badge" role="img" aria-label="${meta.name} icon">${meta.icon}</span>
+              <div>
+                <h3 class="building-card__title">${meta.name}</h3>
+                <p class="building-card__subtitle">ID #${building.id} · ${meta.category}</p>
+              </div>
             </div>
-            <div class="stat-row">
-              <span>Built <strong>${building.built}</strong></span>
-              <span>Active <strong>${building.active}</strong></span>
-              <span>Capacity <strong>${capacity}</strong></span>
-            </div>
-            <div class="bar" aria-hidden="true"></div>
-            <div class="action-row">
-              <button type="button" data-action="build" data-building-id="${building.id}">Build</button>
-              <button type="button" data-action="demolish" data-building-id="${building.id}">Demolish</button>
-              <label class="flex items-center gap-2 text-xs text-slate-300">
-                <span>Workers</span>
-                <input type="number" min="0" step="1" value="${building.active}" data-building-input="${building.id}" />
-              </label>
-              <button type="button" data-action="assign" data-building-id="${building.id}">Assign</button>
-            </div>
+            <span class="building-card__status ${status.className}">${status.label}</span>
+          </header>
+          <div class="stat-row">
+            <span>Workers <strong>${building.active_workers}/${building.max_workers}</strong></span>
+            <span>Cycle <strong>${formatNumber(building.cycle_time)}s</strong></span>
+            <span>${building.enabled ? "Enabled" : "Disabled"}</span>
+          </div>
+          <div class="building-card__divider" aria-hidden="true"></div>
+          <div class="building-card__resources">
+            <span><span>Inputs</span><strong>${formatResourceMap(building.inputs)}</strong></span>
+            <span><span>Outputs</span><strong>${formatResourceMap(building.outputs)}</strong></span>
+            <span><span>Maintenance</span><strong>${formatResourceMap(building.maintenance)}</strong></span>
+          </div>
+          <div class="building-card__divider" aria-hidden="true"></div>
+          <div class="action-row">
+            <label class="flex items-center gap-2 text-xs text-slate-300">
+              <span>Workers</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                value="${building.active_workers}"
+                data-role="worker-input"
+                aria-label="Workers assigned to ${meta.name}"
+              />
+            </label>
+            <button type="button" data-action="set-workers">Apply</button>
+            <button type="button" data-action="toggle" data-enabled="${building.enabled ? "true" : "false"}" class="button--ghost">
+              ${building.enabled ? "Disable" : "Enable"}
+            </button>
+            <button type="button" data-action="demolish" class="button--danger">Demolish</button>
           </div>
         </article>
       `;
-      container.appendChild(article);
+      fragment.appendChild(listItem);
     });
+    buildingList.appendChild(fragment);
   }
 
   function renderJobs() {
+    if (!jobsList) return;
+    if (!state.initialised) {
+      setStatus(jobsStatus, "loading", "Loading workers…");
+      jobsList.innerHTML = "";
+      return;
+    }
+    const jobsData = state.jobs;
+    if (!jobsData) {
+      setStatus(jobsStatus, "error", "Worker data unavailable");
+      return;
+    }
+    setStatus(jobsStatus, null);
+    const used = jobsData.total_workers - jobsData.available_workers;
+    if (jobsCount) {
+      jobsCount.textContent = `${used}/${jobsData.total_workers}`;
+    }
+    if (workersAvailable) {
+      workersAvailable.textContent = `${jobsData.available_workers}`;
+    }
+    if (workersAssigned) {
+      workersAssigned.textContent = `${used}`;
+    }
+    const assignments = jobsData.buildings || {};
     jobsList.innerHTML = "";
-    state.jobs.forEach((job) => {
+    const entries = Object.entries(assignments);
+    if (!entries.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty-placeholder";
+      empty.textContent = "No workers assigned yet. Use the building cards to assign staff.";
+      jobsList.appendChild(empty);
+      return;
+    }
+    entries.forEach(([id, info]) => {
+      const building = state.buildings.find((entry) => entry.id === Number(id));
+      const meta = building ? (BUILDING_TYPES[building.type] || { name: building.name, icon: "🏛️" }) : { name: `Building #${id}`, icon: "🏛️" };
       const card = document.createElement("div");
       card.className = "job-card";
-      card.dataset.jobId = job.id;
       card.innerHTML = `
         <header>
           <div class="flex items-center gap-2 text-slate-100">
-            <span class="icon-badge icon-badge--sm" role="img" aria-label="${job.name} icon">${job.icon}</span>
-            <span>${job.name}</span>
+            <span class="icon-badge icon-badge--sm" role="img" aria-label="${meta.name} icon">${meta.icon}</span>
+            <span>${meta.name}</span>
           </div>
-          <span class="text-xs uppercase tracking-[0.2em] text-slate-400">${job.assigned}/${job.max}</span>
+          <span class="text-xs uppercase tracking-[0.2em] text-slate-400">${info.assigned}/${building ? building.max_workers : info.max || info.assigned}</span>
         </header>
-        <div class="controls">
-          <button type="button" data-action="job-decrement" data-job-id="${job.id}">-</button>
-          <input type="number" min="0" max="${job.max}" value="${job.assigned}" data-job-input="${job.id}" />
-          <button type="button" data-action="job-increment" data-job-id="${job.id}">+</button>
-        </div>
+        <p class="text-xs text-slate-400">Building ID #${id}</p>
       `;
       jobsList.appendChild(card);
     });
   }
 
   function renderTrade() {
-    tradeList.innerHTML = "";
-    state.trade.forEach((item) => {
-      const balance = item.export - item.import;
-      const row = document.createElement("div");
-      row.className = "trade-row";
-      row.dataset.tradeId = item.id;
-      row.innerHTML = `
-        <div class="flex items-center gap-3 text-sm font-semibold text-slate-100">
-          <span class="icon-badge icon-badge--sm" role="img" aria-label="${item.label} icon">${item.icon}</span>
-          <span>${item.label}</span>
-        </div>
-        <div class="controls">
-          <button type="button" class="export" data-action="trade-export" data-trade-id="${item.id}">Export</button>
-          <button type="button" class="import" data-action="trade-import" data-trade-id="${item.id}">Import</button>
-          <label class="flex flex-1 items-center gap-2 text-xs text-slate-300">
-            <span>Export</span>
-            <input type="range" min="0" max="100" step="1" value="${item.export}" data-trade-slider="${item.id}" />
-          </label>
-          <label class="flex items-center gap-2 text-xs text-slate-300">
-            <span>Import</span>
-            <input type="number" min="0" step="1" value="${item.import}" data-trade-input="${item.id}" />
-          </label>
-        </div>
-        <div class="balance ${balance > 0 ? "positive" : balance < 0 ? "negative" : ""}">
-          Balance ${balance > 0 ? "+" : ""}${balance}
-        </div>
-      `;
-      tradeList.appendChild(row);
-    });
-  }
-
-  function updateJobsCount() {
-    const assigned = getTotalAssigned();
-    const total = state.population.total;
-    jobsCountLabel.textContent = `${assigned}/${total}`;
-    updateChips();
-  }
-
-  function adjustBuildingCount(buildingId, delta) {
-    const building = state.buildings.find((entry) => entry.id === buildingId);
-    if (!building) return;
-    const nextBuilt = Math.max(0, building.built + delta);
-    building.built = nextBuilt;
-    const capacity = getCapacity(building);
-    if (building.active > capacity) {
-      building.active = capacity;
-    }
-    saveState();
-    renderBuildings();
-    updateJobsCount();
-  }
-
-  function assignBuildingWorkers(buildingId, requested) {
-    const building = state.buildings.find((entry) => entry.id === buildingId);
-    if (!building) return;
-    const capacity = getCapacity(building);
-    const sanitized = Math.max(0, Math.min(capacity, Number.isFinite(requested) ? requested : 0));
-    const assignedElsewhere = getTotalAssigned() - building.active;
-    const available = Math.max(0, state.population.total - assignedElsewhere);
-    const finalValue = Math.min(sanitized, available);
-    building.active = finalValue;
-    saveState();
-    renderBuildings();
-    updateJobsCount();
-  }
-
-  function adjustJob(jobId, delta) {
-    const job = state.jobs.find((entry) => entry.id === jobId);
-    if (!job) return;
-    const otherAssigned = getTotalAssigned() - job.assigned;
-    const available = Math.max(0, state.population.total - otherAssigned);
-    const desired = job.assigned + delta;
-    const limited = Math.min(job.max, Math.max(0, desired));
-    job.assigned = Math.min(limited, available);
-    saveState();
-    renderJobs();
-    updateJobsCount();
-  }
-
-  function setJob(jobId, value) {
-    const job = state.jobs.find((entry) => entry.id === jobId);
-    if (!job) return;
-    const otherAssigned = getTotalAssigned() - job.assigned;
-    const available = Math.max(0, state.population.total - otherAssigned);
-    const sanitized = Math.max(0, Math.min(job.max, Number(value)));
-    job.assigned = Math.min(sanitized, available);
-    saveState();
-    renderJobs();
-    updateJobsCount();
-  }
-
-  function adjustTrade(itemId, changes) {
-    const item = state.trade.find((entry) => entry.id === itemId);
-    if (!item) return;
-    if (typeof changes.export === "number") {
-      item.export = Math.max(0, changes.export);
-    }
-    if (typeof changes.import === "number") {
-      item.import = Math.max(0, changes.import);
-    }
-    saveState();
-    renderTrade();
-  }
-
-  function handleBuildingActions(event) {
-    const button = event.target.closest("button[data-action]");
-    if (!button) return;
-    const { action, buildingId } = button.dataset;
-    if (!buildingId) return;
-    if (action === "build") {
-      adjustBuildingCount(buildingId, 1);
-    } else if (action === "demolish") {
-      adjustBuildingCount(buildingId, -1);
-    } else if (action === "assign") {
-      const input = document.querySelector(`[data-building-input="${buildingId}"]`);
-      const desired = input ? Number(input.value) : 0;
-      assignBuildingWorkers(buildingId, desired);
-    }
-  }
-
-  function handleBuildingInput(event) {
-    const input = event.target;
-    if (!input.matches("input[data-building-input]")) return;
-    const buildingId = input.dataset.buildingInput;
-    const value = Number(input.value);
-    const building = state.buildings.find((entry) => entry.id === buildingId);
-    if (!building) return;
-    const capacity = getCapacity(building);
-    const sanitized = Math.max(0, Math.min(capacity, Number.isFinite(value) ? value : 0));
-    input.value = sanitized;
-  }
-
-  function handleJobActions(event) {
-    const button = event.target.closest("button[data-action]");
-    if (!button) return;
-    const { action, jobId } = button.dataset;
-    if (!jobId) return;
-    if (action === "job-increment") {
-      adjustJob(jobId, 1);
-    } else if (action === "job-decrement") {
-      adjustJob(jobId, -1);
-    }
-  }
-
-  function handleJobInput(event) {
-    const input = event.target;
-    if (!input.matches("input[data-job-input]")) return;
-    const jobId = input.dataset.jobInput;
-    const value = Number(input.value);
-    if (!Number.isFinite(value)) {
-      input.value = 0;
+    if (!tradeList) return;
+    if (!state.initialised) {
+      setStatus(tradeStatus, "loading", "Loading trade…");
+      tradeList.innerHTML = "";
       return;
     }
-    setJob(jobId, value);
-  }
-
-  function handleTradeActions(event) {
-    const button = event.target.closest("button[data-action]");
-    if (!button) return;
-    const { action, tradeId } = button.dataset;
-    const item = state.trade.find((entry) => entry.id === tradeId);
-    if (!item) return;
-    if (action === "trade-export") {
-      adjustTrade(tradeId, { export: item.export + 1 });
-    } else if (action === "trade-import") {
-      adjustTrade(tradeId, { import: item.import + 1 });
+    const tradeData = state.trade || {};
+    tradeList.innerHTML = "";
+    const entries = Object.entries(tradeData);
+    if (!entries.length) {
+      setStatus(tradeStatus, null);
+      const empty = document.createElement("div");
+      empty.className = "empty-placeholder";
+      empty.textContent = "Trade channels will appear once configured.";
+      tradeList.appendChild(empty);
+      return;
     }
-  }
-
-  function handleTradeInputs(event) {
-    const target = event.target;
-    if (target.matches("input[data-trade-slider]")) {
-      const tradeId = target.dataset.tradeSlider;
-      adjustTrade(tradeId, { export: Number(target.value) });
-    }
-    if (target.matches("input[data-trade-input]")) {
-      const tradeId = target.dataset.tradeInput;
-      adjustTrade(tradeId, { import: Number(target.value) });
-    }
-  }
-
-  function attachAccordion() {
-    const triggers = document.querySelectorAll(".accordion-trigger");
-    triggers.forEach((trigger, index) => {
-      const accordion = trigger.closest(".accordion");
-      if (!accordion) return;
-      trigger.addEventListener("click", () => {
-        accordion.classList.toggle("open");
-      });
-      if (index === 0) {
-        accordion.classList.add("open");
-      }
+    setStatus(tradeStatus, null);
+    const fragment = document.createDocumentFragment();
+    entries.forEach(([resourceKey, info]) => {
+      const meta = RESOURCE_INFO[resourceKey] || { label: capitalise(resourceKey), icon: "📦" };
+      const estimate = Number(info.estimate_per_min || 0);
+      const row = document.createElement("div");
+      row.className = "trade-row";
+      row.dataset.resource = resourceKey;
+      row.innerHTML = `
+        <div class="flex items-center gap-3 text-sm font-semibold text-slate-100">
+          <span class="icon-badge icon-badge--sm" role="img" aria-label="${meta.label} icon">${meta.icon}</span>
+          <span>${meta.label}</span>
+        </div>
+        <div class="controls">
+          <label>
+            Mode
+            <select data-trade-mode="${resourceKey}">
+              <option value="pause" ${info.mode === "pause" ? "selected" : ""}>Pause</option>
+              <option value="import" ${info.mode === "import" ? "selected" : ""}>Import</option>
+              <option value="export" ${info.mode === "export" ? "selected" : ""}>Export</option>
+            </select>
+          </label>
+          <label>
+            Rate / min
+            <input
+              type="number"
+              min="0"
+              step="1"
+              value="${formatNumber(info.rate_per_min)}"
+              data-trade-rate="${resourceKey}"
+            />
+          </label>
+          <div class="trade-row__meta">
+            <span class="price-tag">${formatNumber(info.price || 0)} gold</span>
+            <span class="estimate-tag ${estimate < 0 ? "negative" : ""}">${formatRate(estimate)} / min</span>
+          </div>
+        </div>
+      `;
+      fragment.appendChild(row);
     });
+    tradeList.appendChild(fragment);
   }
 
-  document.getElementById("building-accordion").addEventListener("click", handleBuildingActions);
-  document.getElementById("building-accordion").addEventListener("change", handleBuildingInput);
-  jobsList.addEventListener("click", handleJobActions);
-  jobsList.addEventListener("change", handleJobInput);
-  tradeList.addEventListener("click", handleTradeActions);
-  tradeList.addEventListener("input", handleTradeInputs);
+  async function refreshAll() {
+    if (!state.initialised) return;
+    try {
+      const [hudData, buildingData] = await Promise.all([
+        callApi("/api/hud"),
+        callApi("/api/buildings"),
+      ]);
+      state.hud = hudData.hud || state.hud;
+      state.trade = hudData.trade || state.trade;
+      state.buildings = buildingData.buildings || [];
+      state.jobs = buildingData.jobs || hudData.jobs || state.jobs;
+      renderHud();
+      renderBuildings();
+      renderJobs();
+      renderTrade();
+    } catch (error) {
+      setStatus(hudStatus, "error", error.message || "Failed to refresh data");
+    }
+  }
 
-  renderBuildings();
-  renderJobs();
-  renderTrade();
-  attachAccordion();
-  updateJobsCount();
-  updateChips();
+  async function performAction(sectionElement, message, action, { refresh = true } = {}) {
+    if (sectionElement) {
+      setStatus(sectionElement, "loading", message);
+    }
+    try {
+      await action();
+      if (refresh) {
+        await refreshAll();
+      }
+      if (sectionElement) {
+        setStatus(sectionElement, null);
+      }
+    } catch (error) {
+      if (sectionElement) {
+        setStatus(sectionElement, "error", error.message || "Operation failed");
+      }
+      throw error;
+    }
+  }
+
+  async function updateBuildingWorkers(buildingId, desired) {
+    const building = state.buildings.find((entry) => entry.id === buildingId);
+    if (!building) {
+      throw new Error("Unknown building");
+    }
+    const clamped = Math.max(0, Math.min(Math.floor(desired), building.max_workers));
+    const delta = clamped - building.active_workers;
+    if (delta === 0) {
+      return;
+    }
+    if (delta > 0) {
+      await performAction(
+        buildingStatus,
+        "Assigning workers…",
+        () => callApi("/api/actions/assign", { method: "POST", body: { id: buildingId, workers: delta } }),
+        { refresh: false },
+      );
+    } else {
+      await performAction(
+        buildingStatus,
+        "Unassigning workers…",
+        () =>
+          callApi("/api/actions/unassign", {
+            method: "POST",
+            body: { id: buildingId, workers: Math.abs(delta) },
+          }),
+        { refresh: false },
+      );
+    }
+    await refreshAll();
+  }
+
+  function attachEventListeners() {
+    if (buildForm) {
+      buildForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!buildSelect) return;
+        const type = buildSelect.value;
+        if (!type) return;
+        performAction(
+          buildingStatus,
+          "Constructing building…",
+          () => callApi("/api/actions/build", { method: "POST", body: { type } }),
+        ).catch(() => {});
+      });
+    }
+
+    if (buildingList) {
+      buildingList.addEventListener("click", (event) => {
+        const button = event.target.closest("button[data-action]");
+        if (!button) return;
+        const item = button.closest("[data-building-id]");
+        if (!item) return;
+        const buildingId = Number(item.dataset.buildingId);
+        if (!Number.isFinite(buildingId)) return;
+        const action = button.dataset.action;
+        if (action === "set-workers") {
+          const input = item.querySelector("input[data-role=\"worker-input\"]");
+          const desired = input ? Number(input.value) : 0;
+          updateBuildingWorkers(buildingId, desired).catch(() => {});
+        } else if (action === "toggle") {
+          const enabled = button.dataset.enabled === "true";
+          performAction(
+            buildingStatus,
+            enabled ? "Disabling building…" : "Enabling building…",
+            () =>
+              callApi("/api/actions/toggle", {
+                method: "POST",
+                body: { id: buildingId, enabled: !enabled },
+              }),
+          ).catch(() => {});
+        } else if (action === "demolish") {
+          performAction(
+            buildingStatus,
+            "Demolishing building…",
+            () => callApi("/api/actions/demolish", { method: "POST", body: { id: buildingId } }),
+          ).catch(() => {});
+        }
+      });
+    }
+
+    if (buildingList) {
+      buildingList.addEventListener("change", (event) => {
+        const input = event.target;
+        if (!input.matches("input[data-role=\"worker-input\"]")) return;
+        const item = input.closest("[data-building-id]");
+        if (!item) return;
+        const buildingId = Number(item.dataset.buildingId);
+        const building = state.buildings.find((entry) => entry.id === buildingId);
+        if (!building) return;
+        const value = Math.max(0, Math.min(Number(input.value) || 0, building.max_workers));
+        input.value = value;
+      });
+    }
+
+    if (tradeList) {
+      tradeList.addEventListener("change", (event) => {
+        const target = event.target;
+        if (target.matches("select[data-trade-mode]")) {
+          const resource = target.dataset.tradeMode;
+          const mode = target.value;
+          performAction(
+            tradeStatus,
+            "Updating trade mode…",
+            () => callApi("/api/actions/trade/mode", { method: "POST", body: { resource, mode } }),
+          ).catch(() => {});
+        }
+        if (target.matches("input[data-trade-rate]")) {
+          const resource = target.dataset.tradeRate;
+          const rate = Math.max(0, Number(target.value) || 0);
+          target.value = rate;
+          performAction(
+            tradeStatus,
+            "Updating trade rate…",
+            () => callApi("/api/actions/trade/rate", { method: "POST", body: { resource, rate } }),
+          ).catch(() => {});
+        }
+      });
+    }
+  }
+
+  async function bootstrap() {
+    populateBuildOptions();
+    setStatus(hudStatus, "loading", "Initialising game…");
+    setStatus(buildingStatus, "loading", "Initialising game…");
+    setStatus(jobsStatus, "loading", "Initialising game…");
+    setStatus(tradeStatus, "loading", "Initialising game…");
+    try {
+      const data = await callApi("/api/init", { method: "POST" });
+      state.hud = data.hud || null;
+      state.buildings = data.buildings || [];
+      state.jobs = data.jobs || null;
+      state.trade = data.trade || {};
+      state.initialised = true;
+      renderHud();
+      renderBuildings();
+      renderJobs();
+      renderTrade();
+    } catch (error) {
+      const message = error.message || "Failed to initialise game";
+      setStatus(hudStatus, "error", message);
+      setStatus(buildingStatus, "error", message);
+      setStatus(jobsStatus, "error", message);
+      setStatus(tradeStatus, "error", message);
+      return;
+    }
+    await refreshAll();
+  }
+
+  attachEventListeners();
+  bootstrap();
 })();

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,10 @@ body {
   font-family: inherit;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .chip {
   display: flex;
   flex-direction: column;
@@ -74,6 +78,46 @@ body {
   font-size: 1.125rem;
   font-weight: 600;
   letter-spacing: 0.08em;
+}
+
+.panel-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px dashed rgb(71 85 105 / 0.6);
+  background: rgb(15 23 42 / 0.6);
+  padding: 0.65rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: rgb(148 163 184);
+}
+
+.panel-status.loading::before {
+  content: "";
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  border: 2px solid rgb(148 163 184 / 0.3);
+  border-top-color: rgb(148 163 184);
+  animation: spin 1s linear infinite;
+}
+
+.panel-status.error {
+  border-color: rgb(248 113 113 / 0.6);
+  color: rgb(252 165 165);
+  background: rgb(127 29 29 / 0.3);
+}
+
+.panel-status[hidden] {
+  display: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .accordion {
@@ -177,6 +221,25 @@ body {
   background: rgb(71 85 105 / 0.8);
 }
 
+.button--ghost {
+  background: transparent;
+  border: 1px solid rgb(71 85 105 / 0.6);
+}
+
+.button--ghost:hover {
+  background: rgb(30 41 59 / 0.6);
+}
+
+.button--danger {
+  border-color: rgb(248 113 113 / 0.4);
+  background: rgb(127 29 29 / 0.4);
+  color: rgb(252 165 165);
+}
+
+.button--danger:hover {
+  background: rgb(127 29 29 / 0.6);
+}
+
 .action-row input[type="number"],
 .job-card input[type="number"],
 .trade-row input[type="number"] {
@@ -264,6 +327,242 @@ body {
   font-size: 0.75rem;
   line-height: 1.4;
   color: rgb(226 232 240);
+}
+
+.hud-messages {
+  min-height: 1rem;
+}
+
+.notification-list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.notification-list li {
+  border-radius: 0.65rem;
+  border: 1px solid rgb(71 85 105 / 0.6);
+  background: rgb(15 23 42 / 0.5);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: rgb(226 232 240);
+}
+
+.notification-list li::before {
+  content: "⚠️";
+  margin-right: 0.5rem;
+}
+
+.notification-list li.empty::before {
+  content: "✅";
+}
+
+.notification-list li.empty {
+  color: rgb(148 163 184);
+}
+
+.build-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.build-select {
+  min-width: 12rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgb(51 65 85 / 0.8);
+  background: rgb(15 23 42 / 0.8);
+  padding: 0.45rem 0.75rem;
+  font-size: 0.75rem;
+  color: rgb(226 232 240);
+}
+
+.build-button {
+  border-radius: 0.6rem;
+  border: 1px solid rgb(94 234 212 / 0.4);
+  background: rgb(16 185 129 / 0.15);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(134 239 172);
+}
+
+.build-button:hover {
+  background: rgb(16 185 129 / 0.25);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.empty-placeholder {
+  border-radius: 0.75rem;
+  border: 1px dashed rgb(71 85 105 / 0.6);
+  padding: 1.25rem;
+  font-size: 0.8rem;
+  text-align: center;
+  color: rgb(148 163 184);
+  background: rgb(15 23 42 / 0.4);
+}
+
+.worker-summary {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+  font-size: 0.8rem;
+  color: rgb(148 163 184);
+}
+
+.worker-summary__line {
+  display: flex;
+  justify-content: space-between;
+}
+
+.building-card {
+  position: relative;
+}
+
+.building-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.building-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgb(226 232 240);
+}
+
+.building-card__subtitle {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.building-card__status {
+  border-radius: 9999px;
+  border: 1px solid rgb(51 65 85 / 0.8);
+  background: rgb(30 41 59 / 0.6);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.building-card__status.is-active {
+  border-color: rgb(45 212 191 / 0.6);
+  color: rgb(94 234 212);
+}
+
+.building-card__status.is-paused {
+  border-color: rgb(148 163 184 / 0.4);
+}
+
+.building-card__status.is-error {
+  border-color: rgb(248 113 113 / 0.4);
+  color: rgb(252 165 165);
+}
+
+.building-card__resources {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  color: rgb(148 163 184);
+}
+
+.building-card__resources span {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.building-card__divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, rgb(51 65 85 / 0), rgb(71 85 105 / 0.8), rgb(51 65 85 / 0));
+  margin: 0.75rem 0;
+}
+
+.trade-row__meta {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: rgb(148 163 184);
+}
+
+.trade-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgb(148 163 184);
+}
+
+.trade-row select {
+  border-radius: 0.5rem;
+  border: 1px solid rgb(51 65 85 / 0.8);
+  background: rgb(15 23 42 / 0.8);
+  padding: 0.45rem 0.75rem;
+  color: rgb(226 232 240);
+}
+
+.trade-row .trade-rate-value {
+  font-weight: 700;
+  color: rgb(226 232 240);
+}
+
+.trade-row .price-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgb(71 85 105 / 0.6);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+
+.trade-row .price-tag::before {
+  content: "💰";
+}
+
+.trade-row .estimate-tag::before {
+  content: "⏱️";
+  margin-right: 0.25rem;
+}
+
+.trade-row .estimate-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgb(94 234 212);
+}
+
+.trade-row .estimate-tag.negative {
+  color: rgb(252 165 165);
 }
 
 .trade-row {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% block content %}
 <header class="bg-slate-800/80 backdrop-blur border-b border-slate-700">
-  <div class="max-w-6xl mx-auto px-4 py-4">
-    <h1 class="text-2xl font-semibold tracking-wide mb-4">Idle Village Overview</h1>
-    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-8">
-      <div class="chip" data-resource="happiness">😊 Happiness <span class="value">82%</span></div>
-      <div class="chip" data-resource="population">👤 Population <span class="value">15</span></div>
-      <div class="chip" data-resource="gold">🪙 Gold <span class="value">320</span></div>
-      <div class="chip" data-resource="wood">🪵 Wood <span class="value">210</span></div>
-      <div class="chip" data-resource="planks">🧱 Planks <span class="value">46</span></div>
-      <div class="chip" data-resource="stone">🪨 Stone <span class="value">138</span></div>
-      <div class="chip" data-resource="tools">🛠️ Tools <span class="value">12</span></div>
-      <div class="chip" data-resource="wheat">🌾 Wheat <span class="value">75</span></div>
+  <div class="max-w-6xl mx-auto px-4 py-4 space-y-4">
+    <h1 class="text-2xl font-semibold tracking-wide">Idle Village Overview</h1>
+    <div id="hud-status" class="panel-status" hidden>Loading HUD…</div>
+    <div
+      class="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-8"
+      id="hud-chips"
+      aria-live="polite"
+      aria-busy="true"
+    ></div>
+    <div id="hud-messages" class="hud-messages" aria-live="polite">
+      <ul id="hud-warnings" class="notification-list"></ul>
     </div>
   </div>
 </header>
@@ -20,77 +20,36 @@
   <div class="max-w-6xl mx-auto px-4 py-6">
     <div class="grid gap-6 lg:grid-cols-3">
       <section class="panel" id="buildings">
-        <div class="panel-header">
+        <div class="panel-header flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="panel-title">Buildings</h2>
+          <form id="build-form" class="build-form" autocomplete="off">
+            <label class="sr-only" for="build-type">Construct building</label>
+            <select id="build-type" name="build-type" class="build-select"></select>
+            <button type="submit" class="build-button">Construct</button>
+          </form>
         </div>
-        <div class="space-y-4" id="building-accordion">
-          <div class="accordion" data-group="wood">
-            <button class="accordion-trigger" type="button">
-              <span class="font-medium">Wood</span>
-              <svg class="h-4 w-4 transition-transform" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.08 1.04l-4.25 4.25a.75.75 0 01-1.06 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-              </svg>
-            </button>
-            <div class="accordion-content">
-              <ul class="space-y-4" data-category="wood"></ul>
-            </div>
-          </div>
-
-          <div class="accordion" data-group="stone">
-            <button class="accordion-trigger" type="button">
-              <span class="font-medium">Stone</span>
-              <svg class="h-4 w-4 transition-transform" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.08 1.04l-4.25 4.25a.75.75 0 01-1.06 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-              </svg>
-            </button>
-            <div class="accordion-content">
-              <ul class="space-y-4" data-category="stone"></ul>
-            </div>
-          </div>
-
-          <div class="accordion" data-group="crops">
-            <button class="accordion-trigger" type="button">
-              <span class="font-medium">Crops</span>
-              <svg class="h-4 w-4 transition-transform" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.08 1.04l-4.25 4.25a.75.75 0 01-1.06 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-              </svg>
-            </button>
-            <div class="accordion-content">
-              <ul class="space-y-4" data-category="crops"></ul>
-            </div>
-          </div>
-        </div>
+        <div id="buildings-status" class="panel-status" hidden>Loading buildings…</div>
+        <ul class="space-y-4" id="building-list" aria-live="polite"></ul>
       </section>
 
       <section class="panel" id="jobs">
         <div class="panel-header justify-between">
-          <div>
-            <h2 class="panel-title">Jobs <span id="jobs-count">15/20</span> 👤</h2>
-          </div>
-          <div class="relative group">
-            <button class="tooltip-trigger" type="button">Costs</button>
-            <div class="tooltip">
-              <div class="tooltip-arrow"></div>
-              <div class="tooltip-content">
-                <p class="text-sm text-slate-200">
-                  Assigning workers consumes 1 🍞 per day. Demolishing refunds 50% of materials.
-                </p>
-              </div>
-            </div>
-          </div>
+          <h2 class="panel-title">Workers <span id="jobs-count">0/0</span> 👤</h2>
         </div>
-        <div class="space-y-3" id="jobs-list">
-          <!-- Jobs rendered by JS -->
+        <div id="jobs-status" class="panel-status" hidden>Loading workers…</div>
+        <div class="worker-summary">
+          <p class="worker-summary__line">Available: <span id="workers-available">0</span></p>
+          <p class="worker-summary__line">Assigned: <span id="workers-assigned">0</span></p>
         </div>
+        <div class="space-y-3" id="jobs-list" aria-live="polite"></div>
       </section>
 
       <section class="panel" id="trade">
         <div class="panel-header">
           <h2 class="panel-title">Trade</h2>
         </div>
-        <div class="space-y-4" id="trade-list">
-          <!-- Trade rows rendered by JS -->
-        </div>
+        <div id="trade-status" class="panel-status" hidden>Loading trade…</div>
+        <div class="space-y-4" id="trade-list" aria-live="polite"></div>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add JSON API routes in the Flask app that wrap `api.ui_bridge` for initialisation, snapshots, and actions
- refactor the front-end script to fetch snapshots/actions from the backend, rendering live state and error/loading indicators
- refresh the index template and styles to support the asynchronous workflow and new HUD/building/trade layouts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda580be3883328d6e66350764d62d