### PR TITLE
Expose season snapshot and persistence

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -8,6 +8,11 @@ from core.persistence import load_game as core_load_game, save_game as core_save
 from core.resources import Resource
 
 
+def _season_snapshot(state=None) -> Dict[str, object]:
+    game_state = state or get_game_state()
+    return game_state.season_clock.to_dict()
+
+
 # ---------------------------------------------------------------------------
 # Initialisation and ticking
 
@@ -17,7 +22,7 @@ def init_game() -> Dict[str, object]:
 
     state = get_game_state()
     state.reset()
-    return {"ok": True}
+    return {"ok": True, "season": _season_snapshot(state)}
 
 
 def tick(dt: float) -> Dict[str, object]:
@@ -25,7 +30,7 @@ def tick(dt: float) -> Dict[str, object]:
 
     state = get_game_state()
     state.tick(max(0.0, float(dt)))
-    return {"ok": True}
+    return {"ok": True, "season": _season_snapshot(state)}
 
 
 # ---------------------------------------------------------------------------

--- a/core/config.py
+++ b/core/config.py
@@ -96,10 +96,10 @@ STARTING_RESOURCES: Dict[Resource, float] = {
 }
 
 SEASON_MODIFIERS: Dict[str, Dict[str, float]] = {
-    "primavera": {"global": 1.0, WHEAT_FARM: 1.05},
-    "verano": {"global": 1.0, WHEAT_FARM: 1.1},
-    "otoño": {"global": 1.0, BREWERY: 1.05},
-    "invierno": {"global": 0.95},
+    "Spring": {"global": 1.0, WHEAT_FARM: 1.05},
+    "Summer": {"global": 1.0, WHEAT_FARM: 1.1},
+    "Autumn": {"global": 1.0, BREWERY: 1.05},
+    "Winter": {"global": 0.95},
 }
 
 NOTIFICATION_QUEUE_LIMIT = 50

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -21,6 +21,7 @@ def save_game(path: str) -> None:
         "version": SAVE_VERSION,
         "season": game_state.season,
         "season_time_left": game_state.season_time_left_sec,
+        "clock": game_state.season_clock.export_state(),
         "inventory": game_state.inventory.bulk_export(),
         "workers": {
             "total": game_state.worker_pool.total_workers,
@@ -47,11 +48,14 @@ def load_game(path: str) -> None:
     game_state = get_game_state()
     game_state.reset()
 
-    season = str(data.get("season", game_state.season))
-    time_left = float(data.get("season_time_left", game_state.season_time_left_sec))
-    game_state.season_clock.load(season, time_left)
-    game_state.season = game_state.season_clock.get_current_season()
-    game_state.season_time_left_sec = game_state.season_clock.get_time_left()
+    clock_data = data.get("clock")
+    if isinstance(clock_data, dict):
+        game_state.season_clock.load(clock_data)
+    else:
+        season = str(data.get("season", game_state.season))
+        time_left = float(data.get("season_time_left", game_state.season_time_left_sec))
+        game_state.season_clock.load(season, time_left)
+    game_state._sync_season_state()
 
     inventory_data = data.get("inventory", {})
     quantities = inventory_data.get("quantities", {})

--- a/core/timeclock.py
+++ b/core/timeclock.py
@@ -1,40 +1,99 @@
 """Season and time tracking for the game."""
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 
 class SeasonClock:
     """Rotating season clock with fixed durations."""
 
-    def __init__(self, seasons: List[str] | None = None, season_duration: float = 180.0) -> None:
-        self.seasons = seasons or ["primavera", "verano", "otoño", "invierno"]
-        self.season_duration = season_duration
+    SEASON_NAMES = ["Spring", "Summer", "Autumn", "Winter"]
+    SEASON_COLORS = {
+        "Spring": "#FACC15",
+        "Summer": "#22C55E",
+        "Autumn": "#B45309",
+        "Winter": "#38BDF8",
+    }
+
+    def __init__(
+        self,
+        seasons: List[str] | None = None,
+        season_duration: float = 180.0,
+    ) -> None:
+        self.seasons = list(seasons or self.SEASON_NAMES)
+        self.ticks_per_season = float(season_duration)
         self.current_index = 0
-        self.time_left = season_duration
+        self.tick_within_season = 0.0
 
+    # ------------------------------------------------------------------
     def update(self, dt: float) -> None:
-        self.time_left -= dt
-        while self.time_left <= 0:
-            self.current_index = (self.current_index + 1) % len(self.seasons)
-            self.time_left += self.season_duration
+        """Advance the clock ``dt`` ticks, rolling seasons as required."""
 
+        if dt <= 0:
+            return
+        self.tick_within_season += dt
+        while self.tick_within_season >= self.ticks_per_season and self.ticks_per_season > 0:
+            self.tick_within_season -= self.ticks_per_season
+            self.current_index = (self.current_index + 1) % len(self.seasons)
+
+    # ------------------------------------------------------------------
     def get_current_season(self) -> str:
         return self.seasons[self.current_index]
 
     def get_time_left(self) -> float:
-        return max(0.0, self.time_left)
+        return max(0.0, self.ticks_per_season - self.tick_within_season)
 
-    def to_dict(self) -> dict:
+    def get_progress(self) -> float:
+        if self.ticks_per_season <= 0:
+            return 0.0
+        progress = self.tick_within_season / self.ticks_per_season
+        return min(max(progress, 0.0), 1.0)
+
+    def get_color(self) -> str:
+        return self.SEASON_COLORS.get(self.get_current_season(), "#38BDF8")
+
+    def to_dict(self) -> Dict[str, float | int | str]:
         return {
-            "current_season": self.get_current_season(),
-            "time_left": self.get_time_left(),
+            "season_name": self.get_current_season(),
+            "season_index": self.current_index,
+            "progress": self.get_progress(),
+            "color_hex": self.get_color(),
         }
 
-    def load(self, season: str, time_left: float) -> None:
+    def export_state(self) -> Dict[str, float | int]:
+        return {
+            "season_index": self.current_index,
+            "tick_within_season": self.tick_within_season,
+            "ticks_per_season": self.ticks_per_season,
+        }
+
+    def load(self, season: str | Dict[str, float | int], time_left: float | None = None) -> None:
+        """Restore state from historical data.
+
+        The legacy format (``season`` + ``time_left``) is still supported in
+        addition to the structured ``clock`` payload.
+        """
+
+        if isinstance(season, dict):
+            data = season
+            index = int(data.get("season_index", self.current_index))
+            self.current_index = index % max(1, len(self.seasons))
+            self.ticks_per_season = float(data.get("ticks_per_season", self.ticks_per_season))
+            self.tick_within_season = float(data.get("tick_within_season", self.tick_within_season))
+            # Clamp against negative or overflow values.
+            if self.tick_within_season < 0:
+                self.tick_within_season = 0.0
+            if self.ticks_per_season <= 0:
+                self.ticks_per_season = 1.0
+            self.tick_within_season %= self.ticks_per_season
+            return
+
         if season in self.seasons:
             self.current_index = self.seasons.index(season)
         else:
             self.seasons.insert(0, season)
             self.current_index = 0
-        self.time_left = max(0.0, time_left)
+        self.tick_within_season = 0.0
+        if time_left is not None:
+            inferred = max(0.0, float(time_left))
+            self.tick_within_season = max(0.0, self.ticks_per_season - inferred)

--- a/static/styles.css
+++ b/static/styles.css
@@ -33,6 +33,40 @@ body {
   color: rgb(226 232 240);
 }
 
+#season-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  text-align: right;
+}
+
+.season-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgb(226 232 240 / 0.8);
+}
+
+.season-track {
+  position: relative;
+  width: clamp(10rem, 35vw, 16rem);
+  height: 0.25rem;
+  border-radius: 9999px;
+  background: rgb(51 65 85 / 0.6);
+  overflow: hidden;
+}
+
+.season-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: #38bdf8;
+  transition: width 0.3s ease, background-color 0.3s ease;
+}
+
 .icon-badge {
   display: inline-flex;
   align-items: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,16 @@
 {% block content %}
 <header class="bg-slate-800/80 backdrop-blur border-b border-slate-700">
   <div class="max-w-6xl mx-auto px-4 py-4">
-    <h1 class="text-2xl font-semibold tracking-wide mb-4">Idle Village Overview</h1>
-    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <h1 class="text-2xl font-semibold tracking-wide">Idle Village Overview</h1>
+      <div id="season-bar" class="season-bar">
+        <span id="season-label" class="season-label">Season</span>
+        <div class="season-track" aria-hidden="true">
+          <div id="season-fill" class="season-fill"></div>
+        </div>
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3 mt-4 sm:grid-cols-4 lg:grid-cols-8">
       <div class="chip" data-resource="happiness">😊 Happiness <span class="value">82%</span></div>
       <div class="chip" data-resource="population">👤 Population <span class="value">15</span></div>
       <div class="chip" data-resource="gold">🪙 Gold <span class="value">320</span></div>

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 """Basic sanity tests for the management game backend."""
 from __future__ import annotations
 
+import math
 import os
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ from api import ui_bridge
 from core import config
 from core.game_state import get_game_state
 from core.resources import Resource
+from core.timeclock import SeasonClock
 
 
 def run_all_tests() -> None:
@@ -19,8 +21,21 @@ def run_all_tests() -> None:
     test_production_cycle()
     test_trade_operations()
     test_season_rotation()
+    test_hud_snapshot_contains_season()
+    test_tick_updates_progress()
+    test_season_color_alignment()
     test_persistence_cycle()
+    test_persistence_preserves_clock()
     print("All backend tests passed")
+
+
+def assert_valid_season_block(season: dict) -> None:
+    expected_keys = {"season_name", "season_index", "progress", "color_hex"}
+    assert set(season.keys()) >= expected_keys, "Season block missing required keys"
+    assert isinstance(season["season_name"], str)
+    assert isinstance(season["season_index"], int)
+    assert 0.0 <= float(season["progress"]) <= 1.0
+    assert isinstance(season["color_hex"], str) and season["color_hex"].startswith("#")
 
 
 def test_building_construction() -> None:
@@ -111,6 +126,49 @@ def test_season_rotation() -> None:
     assert state.season == first_season
 
 
+def test_hud_snapshot_contains_season() -> None:
+    ui_bridge.init_game()
+    snapshot = ui_bridge.get_hud_snapshot()
+    assert "season" in snapshot, "Snapshot must include season block"
+    assert_valid_season_block(snapshot["season"])
+
+
+def test_tick_updates_progress() -> None:
+    ui_bridge.init_game()
+    initial = ui_bridge.get_hud_snapshot()["season"]
+    assert_valid_season_block(initial)
+
+    response = ui_bridge.tick(30.0)
+    progress = response["season"]["progress"]
+    assert progress > initial["progress"], "Progress should increase after ticking"
+    current_index = response["season"]["season_index"]
+
+    previous_progress = progress
+    advanced = False
+    for _ in range(8):
+        payload = ui_bridge.tick(30.0)
+        season = payload["season"]
+        assert_valid_season_block(season)
+        if season["season_index"] != current_index:
+            assert season["progress"] <= 0.02, "Progress should reset when season rolls over"
+            advanced = True
+            break
+        assert season["progress"] >= previous_progress - 1e-6
+        previous_progress = season["progress"]
+    assert advanced, "Season should advance after enough ticks"
+
+
+def test_season_color_alignment() -> None:
+    ui_bridge.init_game()
+    for expected_index, expected_name in enumerate(SeasonClock.SEASON_NAMES):
+        if expected_index == 0:
+            season = ui_bridge.get_hud_snapshot()["season"]
+        else:
+            season = ui_bridge.tick(180.0)["season"]
+        assert season["season_name"] == expected_name
+        assert season["color_hex"] == SeasonClock.SEASON_COLORS[expected_name]
+
+
 def test_persistence_cycle() -> None:
     ui_bridge.init_game()
     build_result = ui_bridge.build_building(config.WHEAT_FARM)
@@ -129,6 +187,30 @@ def test_persistence_cycle() -> None:
     assert restored.assigned_workers == 2
     assert state.inventory.get_amount(Resource.WATER) == 50
 
+
+def test_persistence_preserves_clock() -> None:
+    ui_bridge.init_game()
+    state = get_game_state()
+    ui_bridge.tick(90.0)
+    before = state.season_clock.to_dict()
+    export = state.season_clock.export_state()
+    save_path = Path("tests/_tmp_clock.json")
+    ui_bridge.save_game(str(save_path))
+
+    ui_bridge.tick(30.0)
+    ui_bridge.load_game(str(save_path))
+    os.remove(save_path)
+
+    after = state.season_clock.to_dict()
+    assert after["season_index"] == export["season_index"]
+    assert math.isclose(after["progress"], before["progress"], abs_tol=0.001)
+    assert after["season_name"] == before["season_name"]
+
+    resumed = ui_bridge.tick(10.0)["season"]
+    assert resumed["season_index"] == after["season_index"] or (
+        resumed["season_index"] == (after["season_index"] + 1) % len(SeasonClock.SEASON_NAMES)
+        and resumed["progress"] < 0.05
+    )
 
 if __name__ == "__main__":
     run_all_tests()


### PR DESCRIPTION
## Summary
- add English season names, color metadata, and expose the clock snapshot through the API and HUD
- persist and restore the season clock while updating frontend markup/styles to show a season progress bar
- extend backend tests to cover the season contract, color mapping, and persistence accuracy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddad8f642083329b689ee145818f2b