### PR TITLE
Define building recipes and production helpers

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Mapping, Optional, Tuple
 
 from . import config
 from .inventory import Inventory
 from .resources import Resource
+
+
+Reason = Optional[str]
 
 
 @dataclass
@@ -14,12 +17,8 @@ class Building:
     """Represents a production building."""
 
     type_key: str
+    recipe: config.BuildingRecipe
     name: str
-    max_workers: int
-    inputs_per_cycle: Dict[Resource, float]
-    outputs_per_cycle: Dict[Resource, float]
-    cycle_time_sec: float
-    maintenance_per_min: Dict[Resource, float]
     built: bool = True
     enabled: bool = True
     assigned_workers: int = 0
@@ -32,10 +31,81 @@ class Building:
     def __post_init__(self) -> None:
         self.id = Building._next_id
         Building._next_id += 1
-        self._maintenance_per_sec = {
-            resource: amount / 60.0 for resource, amount in self.maintenance_per_min.items()
-        }
         self._maintenance_notified = False
+        self._last_effective_rate = 0.0
+
+    # ------------------------------------------------------------------
+    @property
+    def max_workers(self) -> int:
+        return self.recipe.max_workers
+
+    @property
+    def inputs_per_cycle(self) -> Mapping[Resource, float]:
+        return self.recipe.inputs
+
+    @property
+    def outputs_per_cycle(self) -> Mapping[Resource, float]:
+        return self.recipe.outputs
+
+    @property
+    def maintenance_per_cycle(self) -> Mapping[Resource, float]:
+        return self.recipe.maintenance
+
+    @property
+    def cycle_time_sec(self) -> float:
+        return self.recipe.cycle_time
+
+    # ------------------------------------------------------------------
+    def can_produce(self, inventory: Inventory) -> Tuple[bool, Reason]:
+        """Return whether the building can run another production cycle."""
+
+        if not self.built:
+            return False, "not_built"
+        if not self.enabled:
+            return False, "disabled"
+        if self.assigned_workers <= 0 or self.max_workers <= 0:
+            return False, "no_workers"
+        if self.maintenance_per_cycle and not inventory.has(self.maintenance_per_cycle):
+            return False, "missing_maintenance"
+        if self.inputs_per_cycle and not inventory.has(self.inputs_per_cycle):
+            return False, "missing_inputs"
+        for resource, amount in self.outputs_per_cycle.items():
+            capacity = inventory.get_capacity(resource)
+            if capacity is None:
+                continue
+            if inventory.get_amount(resource) + amount > capacity + 1e-9:
+                return False, "capacity_full"
+        return True, None
+
+    def effective_rate(
+        self,
+        workers: int,
+        modifiers: Mapping[str, float] | float | None,
+    ) -> float:
+        """Return the effective production rate for ``workers`` and ``modifiers``."""
+
+        if self.max_workers <= 0:
+            base = 0.0
+        else:
+            base = min(1.0, max(0.0, workers / self.max_workers))
+
+        if isinstance(modifiers, Mapping):
+            season_mod = float(modifiers.get("global", 1.0))
+            building_mod = float(modifiers.get(self.type_key, 1.0))
+            modifier_value = season_mod * building_mod
+        elif modifiers is None:
+            modifier_value = 1.0
+        else:
+            modifier_value = float(modifiers)
+        return base * modifier_value
+
+    def next_cycle_eta(self) -> Optional[float]:
+        """Return the estimated time until the next cycle completes."""
+
+        remaining_progress = max(0.0, self.cycle_time_sec - self.cycle_progress)
+        if self._last_effective_rate <= 0:
+            return None
+        return remaining_progress / self._last_effective_rate
 
     # ------------------------------------------------------------------
     def tick(
@@ -43,67 +113,69 @@ class Building:
         dt: float,
         inventory: Inventory,
         notify,
-        production_modifier: float,
+        modifiers: Mapping[str, float] | float | None,
     ) -> None:
         """Advance the building logic by ``dt`` seconds."""
 
-        if not self.built:
-            return
-        if not self.enabled:
-            self.status = "pausado"
-            return
-        if self.assigned_workers <= 0 or self.max_workers <= 0:
-            self.status = "pausado"
+        can_produce, reason = self.can_produce(inventory)
+        if not can_produce:
+            self._handle_inactive_state(reason, notify)
+            self._last_effective_rate = 0.0
             return
 
-        maintenance_cost = {
-            resource: rate * dt for resource, rate in self._maintenance_per_sec.items()
-        }
-        if maintenance_cost and not inventory.has(maintenance_cost):
-            if not self._maintenance_notified:
-                notify(f"{self.name} en pausa: falta mantenimiento")
-                self._maintenance_notified = True
-            self.status = "pausado"
-            return
-        if maintenance_cost:
-            inventory.consume(maintenance_cost)
-            self._maintenance_notified = False
-
-        if self.inputs_per_cycle and not inventory.has(self.inputs_per_cycle):
-            self.status = "falta_insumos"
-            return
-
-        for resource, amount in self.outputs_per_cycle.items():
-            capacity = inventory.get_capacity(resource)
-            if capacity is None:
-                continue
-            if inventory.get_amount(resource) + amount > capacity + 1e-9:
-                self.status = "capacidad_llena"
-                return
-
-        efficiency = min(1.0, max(0.0, self.assigned_workers / self.max_workers))
-        efficiency *= production_modifier
-        if efficiency <= 0:
+        rate = self.effective_rate(self.assigned_workers, modifiers)
+        self._last_effective_rate = rate
+        if rate <= 0:
             self.status = "pausado"
             return
 
-        self.cycle_progress += dt * efficiency
+        self._maintenance_notified = False
 
+        self.cycle_progress += dt * rate
         produced_cycle = False
+
         while self.cycle_progress >= self.cycle_time_sec:
             if self.inputs_per_cycle and not inventory.consume(self.inputs_per_cycle):
                 self.status = "falta_insumos"
                 self.cycle_progress = 0.0
                 return
+            if self.maintenance_per_cycle and not inventory.consume(
+                self.maintenance_per_cycle
+            ):
+                self.status = "falta_mantenimiento"
+                if not self._maintenance_notified:
+                    notify(f"{self.name} en pausa: falta mantenimiento")
+                    self._maintenance_notified = True
+                self.cycle_progress = 0.0
+                return
             residual = inventory.add(self.outputs_per_cycle)
             if residual:
                 self.status = "capacidad_llena"
+                # Keep progress so the cycle can retry once there is room
+                self.cycle_progress = self.cycle_time_sec
                 return
             self.cycle_progress -= self.cycle_time_sec
             produced_cycle = True
 
         if produced_cycle or self.status != "ok":
             self.status = "ok"
+
+    # ------------------------------------------------------------------
+    def _handle_inactive_state(self, reason: Reason, notify) -> None:
+        status_map = {
+            "not_built": "no_construido",
+            "disabled": "pausado",
+            "no_workers": "pausado",
+            "missing_inputs": "falta_insumos",
+            "capacity_full": "capacidad_llena",
+            "missing_maintenance": "falta_mantenimiento",
+        }
+        if reason == "missing_maintenance" and not self._maintenance_notified:
+            notify(f"{self.name} en pausa: falta mantenimiento")
+            self._maintenance_notified = True
+        elif reason != "missing_maintenance":
+            self._maintenance_notified = False
+        self.status = status_map.get(reason, "pausado")
 
     # ------------------------------------------------------------------
     def to_snapshot(self) -> Dict[str, object]:
@@ -117,7 +189,9 @@ class Building:
             "inputs": {res.value: amt for res, amt in self.inputs_per_cycle.items()},
             "outputs": {res.value: amt for res, amt in self.outputs_per_cycle.items()},
             "cycle_time": self.cycle_time_sec,
-            "maintenance": {res.value: amt for res, amt in self.maintenance_per_min.items()},
+            "maintenance": {
+                res.value: amt for res, amt in self.maintenance_per_cycle.items()
+            },
             "status": self.status,
             "enabled": self.enabled,
         }
@@ -136,27 +210,7 @@ class Building:
         cls._next_id = next_id
 
 
-def _coerce_resource_key(key) -> Resource:
-    if isinstance(key, Resource):
-        return key
-    return Resource(key)
-
-
 def build_from_config(type_key: str) -> Building:
-    recipe = config.RECETAS[type_key]
+    recipe = config.BUILDING_RECIPES[type_key]
     name = config.BUILDING_NAMES.get(type_key, type_key.title())
-    inputs = {_coerce_resource_key(res): float(amount) for res, amount in recipe["inputs"].items()}
-    outputs = {_coerce_resource_key(res): float(amount) for res, amount in recipe["outputs"].items()}
-    maintenance = {
-        _coerce_resource_key(res): float(amount)
-        for res, amount in recipe.get("maintenance_per_min", {}).items()
-    }
-    return Building(
-        type_key=type_key,
-        name=name,
-        max_workers=int(recipe["max_workers"]),
-        inputs_per_cycle=inputs,
-        outputs_per_cycle=outputs,
-        cycle_time_sec=float(recipe["cycle_time"]),
-        maintenance_per_min=maintenance,
-    )
+    return Building(type_key=type_key, recipe=recipe, name=name)

--- a/core/game_state.py
+++ b/core/game_state.py
@@ -77,18 +77,19 @@ class GameState:
         self.trade_manager.tick(dt, self.inventory, self.add_notification)
 
         for building in list(self.buildings.values()):
-            modifier = self.get_production_modifier(building)
-            building.tick(dt, self.inventory, self.add_notification, modifier)
+            modifiers = self.get_production_modifiers(building)
+            building.tick(dt, self.inventory, self.add_notification, modifiers)
 
-    def get_production_modifier(self, building: Building) -> float:
+    def get_production_modifiers(self, building: Building) -> Dict[str, float]:
         season_mod = config.SEASON_MODIFIERS.get(self.season, {})
-        modifier = float(season_mod.get("global", 1.0))
-        modifier *= float(season_mod.get(building.type_key, 1.0))
-        return modifier
+        return {
+            "global": float(season_mod.get("global", 1.0)),
+            building.type_key: float(season_mod.get(building.type_key, 1.0)),
+        }
 
     # ------------------------------------------------------------------
     def build_building(self, type_key: str) -> Building:
-        if type_key not in config.RECETAS:
+        if type_key not in config.BUILDING_RECIPES:
             raise ValueError(f"Tipo de edificio desconocido: {type_key}")
         cost = config.COSTOS_CONSTRUCCION.get(type_key, {})
         missing = self._missing_resources(cost)

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -70,7 +70,7 @@ def load_game(path: str) -> None:
     max_id = 0
     for entry in data.get("buildings", []):
         type_key = entry.get("type")
-        if not type_key or type_key not in config.RECETAS:
+        if not type_key or type_key not in config.BUILDING_RECIPES:
             continue
         building = build_from_config(type_key)
         building.id = int(entry.get("id", building.id))

--- a/core/resources.py
+++ b/core/resources.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List
+from typing import Dict, Iterable, List, Mapping
 
 
 class Resource(str, Enum):
@@ -23,4 +23,68 @@ ALL_RESOURCES: List[Resource] = [
     Resource.WATER,
     Resource.GOLD,
     Resource.HOPS,
+]
+
+
+_RESOURCE_BY_ID: Dict[str, Resource] = {resource.value: resource for resource in ALL_RESOURCES}
+_RESOURCE_BY_NAME: Dict[str, Resource] = {
+    resource.name: resource for resource in ALL_RESOURCES
+}
+_RESOURCE_LOOKUP: Dict[str, Resource] = {
+    key.lower(): resource for mapping in (_RESOURCE_BY_ID, _RESOURCE_BY_NAME)
+    for key, resource in mapping.items()
+}
+
+
+def resource_from_id(identifier: str) -> Resource:
+    """Return the resource associated with ``identifier``.
+
+    The lookup accepts the canonical identifier (``Resource.value``) regardless of
+    capitalisation. A :class:`KeyError` is raised if the identifier is unknown.
+    """
+
+    resource = _RESOURCE_LOOKUP.get(str(identifier).strip().lower())
+    if resource is None:
+        raise KeyError(f"Recurso desconocido: {identifier}")
+    return resource
+
+
+def resource_from_name(name: str) -> Resource:
+    """Return the resource associated with a human readable ``name``.
+
+    ``name`` can be either the enum name or the stored identifier. The lookup is
+    case-insensitive to avoid discrepancies between UI and persistence layers.
+    """
+
+    return resource_from_id(name)
+
+
+def normalise_resource(value: Resource | str) -> Resource:
+    """Coerce ``value`` into a :class:`Resource` instance."""
+
+    if isinstance(value, Resource):
+        return value
+    return resource_from_id(value)
+
+
+def normalise_mapping(mapping: Mapping[Resource | str, float]) -> Dict[Resource, float]:
+    """Return a new mapping with normalised resource keys."""
+
+    return {normalise_resource(key): float(amount) for key, amount in mapping.items()}
+
+
+def ensure_resources(iterable: Iterable[Resource | str]) -> List[Resource]:
+    """Return the sequence of resources ensuring each entry is canonical."""
+
+    return [normalise_resource(entry) for entry in iterable]
+
+
+__all__ = [
+    "ALL_RESOURCES",
+    "Resource",
+    "ensure_resources",
+    "normalise_mapping",
+    "normalise_resource",
+    "resource_from_id",
+    "resource_from_name",
 ]


### PR DESCRIPTION
## Summary
- add a structured `BuildingRecipe` definition for each production building including inputs, outputs, cycle time, capacity hooks, and maintenance per cycle
- provide consistent resource ID/name normalisation utilities and tie buildings directly to their recipes with production helper methods
- update game state and persistence to use the new recipe map when instantiating buildings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb05f3e0c833280cee677971c0542