### PR TITLE
Add explicit production recipes for core buildings

### DIFF
--- a/core/resources.py
+++ b/core/resources.py
@@ -11,6 +11,10 @@ class Resource(str, Enum):
     WOOD = "WOOD"
     STONE = "STONE"
     GRAIN = "GRAIN"
+    PLANK = "PLANK"
+    TOOLS = "TOOLS"
+    ORE = "ORE"
+    SEEDS = "SEEDS"
     WATER = "WATER"
     GOLD = "GOLD"
     HOPS = "HOPS"
@@ -20,6 +24,10 @@ ALL_RESOURCES: List[Resource] = [
     Resource.WOOD,
     Resource.STONE,
     Resource.GRAIN,
+    Resource.PLANK,
+    Resource.TOOLS,
+    Resource.ORE,
+    Resource.SEEDS,
     Resource.WATER,
     Resource.GOLD,
     Resource.HOPS,


### PR DESCRIPTION
## Summary
- define resource-consuming production recipes for the core economic buildings and document their per-cycle yields
- extend the resource catalogue and configuration defaults to cover planks, tools, ore, and seeds needed by the new chains
- align the backend tests with the updated production flows and persistence expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb720463c833287f08bc8f4298ff4