### PR TITLE
Implement season-based production modifiers and expose UI data

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -68,9 +68,9 @@ class Building:
             base = min(1.0, max(0.0, workers / self.max_workers))
 
         if isinstance(modifiers, Mapping):
-            season_mod = float(modifiers.get("global", 1.0))
-            building_mod = float(modifiers.get(self.type_key, 1.0))
-            modifier_value = season_mod * building_mod
+            modifier_value = 1.0
+            for value in modifiers.values():
+                modifier_value *= float(value)
         elif modifiers is None:
             modifier_value = 1.0
         else:

--- a/core/config.py
+++ b/core/config.py
@@ -144,10 +144,27 @@ STARTING_RESOURCES: Dict[Resource, float] = {
 }
 
 SEASON_MODIFIERS: Dict[str, Dict[str, float]] = {
-    "Spring": {"global": 1.0, FARMER: 1.05},
-    "Summer": {"global": 1.0, FARMER: 1.1},
-    "Autumn": {"global": 1.0, ARTISAN: 1.05},
-    "Winter": {"global": 0.95, MINER: 0.9},
+    "Spring": {
+        "global": 1.0,
+        FARMER: 1.1,
+    },
+    "Summer": {
+        "global": 1.0,
+        FARMER: 1.2,
+        MINER: 0.9,
+    },
+    "Autumn": {
+        "global": 1.0,
+        ARTISAN: 1.15,
+        MINER: 1.05,
+    },
+    "Winter": {
+        "global": 1.0,
+        FARMER: 0.7,
+        WOODCUTTER_CAMP: 1.1,
+        LUMBER_HUT: 1.1,
+        MINER: 1.05,
+    },
 }
 
 NOTIFICATION_QUEUE_LIMIT = 50


### PR DESCRIPTION
## Summary
- configure season-specific production modifiers per building type and pass them through the season clock
- surface modifier breakdowns in building snapshots so the UI can show applied seasonal effects
- expand backend tests to cover seasonal production changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb82c7958833284b0bc4bd471275d