### PR TITLE
Add import-aware missing input notifications and strengthen backend tests

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -64,6 +64,7 @@ def get_state() -> Dict[str, object]:
         season=_season_snapshot(state),
         buildings=state.snapshot_buildings(),
         production_report=state.production_reports_snapshot(),
+        notifications=state.list_notifications(),
     )
 
 


### PR DESCRIPTION
## Summary
- capture missing input details from building production cycles and generate deduplicated notifications, tagging those resolvable through imports
- expose the notification queue via `/api/state` and expand backend tests to cover atomic production, season effects, and notification lifecycles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de0264577c8332a72671913116d1f3