### PR TITLE
Enhance frontend status rendering and accessibility

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,6 +1,121 @@
 (function () {
   const STORAGE_KEY = "idle-village-state-v1";
 
+  const resourceLabels = {
+    happiness: "Happiness",
+    population: "Population",
+    gold: "Gold",
+    wood: "Wood",
+    planks: "Planks",
+    stone: "Stone",
+    tools: "Tools",
+    wheat: "Wheat",
+    ore: "Ore",
+    seeds: "Seeds",
+  };
+
+  const buildingCatalog = {
+    woodcutter_camp: {
+      slug: "woodcutter-camp",
+      name: "Woodcutter Camp",
+      icon: "🪓",
+      category: "wood",
+      capacityPerBuilding: 2,
+      inputs: {},
+      outputs: { wood: 1 },
+      maintenance: { gold: 0.01 },
+    },
+    lumber_hut: {
+      slug: "lumber-hut",
+      name: "Lumber Hut",
+      icon: "🏚️",
+      category: "wood",
+      capacityPerBuilding: 2,
+      inputs: { wood: 2 },
+      outputs: { planks: 1 },
+      maintenance: { gold: 0.02 },
+    },
+    miner: {
+      slug: "stone-quarry",
+      name: "Stone Quarry",
+      icon: "⛏️",
+      category: "stone",
+      capacityPerBuilding: 3,
+      inputs: {},
+      outputs: { stone: 1, ore: 0.2 },
+      maintenance: { gold: 0.05 },
+    },
+    farmer: {
+      slug: "wheat-farm",
+      name: "Wheat Farm",
+      icon: "🌾",
+      category: "crops",
+      capacityPerBuilding: 2,
+      inputs: { seeds: 1 },
+      outputs: { wheat: 3 },
+      maintenance: { gold: 0.03 },
+    },
+  };
+
+  const buildingTypeBySlug = {};
+  Object.entries(buildingCatalog).forEach(([typeKey, definition]) => {
+    buildingTypeBySlug[definition.slug] = typeKey;
+  });
+
+  function createReport(status, consumed, produced, reason, detail) {
+    return {
+      status: status || "inactive",
+      reason: reason || (status === "produced" ? "cycle_complete" : status || "inactive"),
+      detail: detail || null,
+      consumed: consumed ? { ...consumed } : {},
+      produced: produced ? { ...produced } : {},
+    };
+  }
+
+  function createBuildingState(typeKey, overrides) {
+    const definition = buildingCatalog[typeKey];
+    const slug = definition ? definition.slug : typeKey;
+    const report = overrides && overrides.productionReport;
+    const active = Number(overrides && overrides.active) || 0;
+    const initialStatus =
+      overrides && overrides.productionReport && overrides.productionReport.status
+        ? overrides.productionReport.status
+        : active > 0
+        ? "produced"
+        : "inactive";
+    return {
+      id: slug,
+      type: typeKey,
+      name: (overrides && overrides.name) || (definition && definition.name) || slug,
+      category: (overrides && overrides.category) || (definition && definition.category) || "general",
+      built: Number.isFinite(overrides && overrides.built)
+        ? Number(overrides.built)
+        : 0,
+      active: active,
+      capacityPerBuilding: Number.isFinite(overrides && overrides.capacityPerBuilding)
+        ? Number(overrides.capacityPerBuilding)
+        : definition && definition.capacityPerBuilding
+        ? definition.capacityPerBuilding
+        : 1,
+      icon: (overrides && overrides.icon) || (definition && definition.icon) || "🏠",
+      inputs: {
+        ...(definition ? definition.inputs : {}),
+        ...(overrides && overrides.inputs ? overrides.inputs : {}),
+      },
+      outputs: {
+        ...(definition ? definition.outputs : {}),
+        ...(overrides && overrides.outputs ? overrides.outputs : {}),
+      },
+      maintenance: {
+        ...(definition ? definition.maintenance : {}),
+        ...(overrides && overrides.maintenance ? overrides.maintenance : {}),
+      },
+      productionReport: report
+        ? createReport(report.status, report.consumed, report.produced, report.reason, report.detail)
+        : createReport(initialStatus, definition ? definition.inputs : {}, definition ? definition.outputs : {}),
+    };
+  }
+
   const defaultState = {
     resources: {
       happiness: 82,
@@ -15,42 +130,26 @@
       total: 20,
     },
     buildings: [
-      {
-        id: "woodcutter-camp",
-        name: "Woodcutter Camp",
-        category: "wood",
+      createBuildingState("woodcutter_camp", {
         built: 1,
         active: 1,
-        capacityPerBuilding: 2,
-        icon: "🪓",
-      },
-      {
-        id: "lumber-hut",
-        name: "Lumber Hut",
-        category: "wood",
+        productionReport: createReport("produced", {}, { wood: 1 }),
+      }),
+      createBuildingState("lumber_hut", {
         built: 2,
         active: 4,
-        capacityPerBuilding: 2,
-        icon: "🏚️",
-      },
-      {
-        id: "stone-quarry",
-        name: "Stone Quarry",
-        category: "stone",
+        productionReport: createReport("produced", { wood: 2 }, { planks: 1 }),
+      }),
+      createBuildingState("miner", {
         built: 1,
         active: 3,
-        capacityPerBuilding: 3,
-        icon: "⛏️",
-      },
-      {
-        id: "wheat-farm",
-        name: "Wheat Farm",
-        category: "crops",
+        productionReport: createReport("produced", {}, { stone: 1, ore: 0.2 }),
+      }),
+      createBuildingState("farmer", {
         built: 0,
         active: 0,
-        capacityPerBuilding: 2,
-        icon: "🌾",
-      },
+        productionReport: createReport("inactive", { seeds: 1 }, { wheat: 3 }, "inactive", null),
+      }),
     ],
     jobs: [
       { id: "forester", name: "Forester", assigned: 4, max: 6, icon: "🌲" },
@@ -111,12 +210,147 @@
     state.season = clone(defaultState.season);
   }
 
+  state.buildings = Array.isArray(state.buildings)
+    ? state.buildings.map((entry) => normaliseBuildingEntry(entry)).filter(Boolean)
+    : [];
+  state.jobs = Array.isArray(state.jobs) ? state.jobs : clone(defaultState.jobs);
+  state.trade = Array.isArray(state.trade) ? state.trade : clone(defaultState.trade);
+  state.resources = state.resources || clone(defaultState.resources);
+  state.population = state.population || clone(defaultState.population);
+
   function saveState() {
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     } catch (error) {
       console.warn("Idle Village: failed to save state", error);
     }
+  }
+
+  function normaliseNumeric(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+  }
+
+  function normaliseResourceRecord(record, fallback) {
+    const source = record && typeof record === "object" ? record : fallback || {};
+    const result = {};
+    Object.entries(source).forEach(([key, amount]) => {
+      const numeric = Number(amount);
+      if (Number.isFinite(numeric)) {
+        result[key] = numeric;
+      }
+    });
+    return result;
+  }
+
+  function normaliseReport(report, typeKey, inputs, outputs) {
+    if (!report || typeof report !== "object") {
+      return createReport("inactive", inputs, outputs, "inactive", null);
+    }
+    return createReport(
+      report.status,
+      report.consumed || report.inputs || inputs,
+      report.produced || report.outputs || outputs,
+      report.reason,
+      report.detail
+    );
+  }
+
+  function normaliseBuildingEntry(raw) {
+    if (!raw) return null;
+    const rawId = raw.id ?? raw.slug ?? raw.type ?? raw.type_key;
+    const slugCandidate = typeof raw.slug === "string" ? raw.slug : undefined;
+    const inferredType =
+      raw.type ||
+      raw.type_key ||
+      buildingTypeBySlug[String(slugCandidate || "")] ||
+      buildingTypeBySlug[String(rawId || "")];
+    const definition = inferredType ? buildingCatalog[inferredType] : undefined;
+    const slug = definition?.slug || slugCandidate || (typeof rawId === "string" ? rawId : undefined);
+    const id = raw.id != null ? String(raw.id) : slug || String(Date.now());
+    const category = raw.category || definition?.category || "general";
+    const name = raw.name || definition?.name || slug || id;
+    const icon = raw.icon || definition?.icon || "🏠";
+    const built =
+      raw.built === true
+        ? 1
+        : raw.built === false
+        ? 0
+        : normaliseNumeric(raw.built, definition ? 1 : 0);
+    const active = normaliseNumeric(
+      raw.active ?? raw.active_workers ?? raw.assigned_workers ?? raw.activeWorkers,
+      0
+    );
+    const capacityPerBuilding = Math.max(
+      1,
+      normaliseNumeric(
+        raw.capacityPerBuilding ?? raw.max_workers ?? raw.capacity ?? definition?.capacityPerBuilding,
+        definition?.capacityPerBuilding || 1
+      )
+    );
+    const inputs = normaliseResourceRecord(raw.inputs, definition?.inputs);
+    const outputs = normaliseResourceRecord(raw.outputs, definition?.outputs);
+    const maintenance = normaliseResourceRecord(raw.maintenance, definition?.maintenance);
+    const reportSource = raw.productionReport || raw.production_report || raw.last_report;
+    const productionReport = normaliseReport(reportSource, inferredType, inputs, outputs);
+
+    return {
+      id,
+      slug: slug || id,
+      type: inferredType || raw.type || raw.type_key || buildingTypeBySlug[id] || slug || id,
+      name,
+      category,
+      built: Math.max(0, built),
+      active: Math.max(0, active),
+      capacityPerBuilding,
+      icon,
+      inputs,
+      outputs,
+      maintenance,
+      productionReport,
+    };
+  }
+
+  function updateBuildingReportFromState(building) {
+    if (!building) return;
+    const definition = buildingCatalog[building.type] || buildingCatalog[buildingTypeBySlug[building.slug || ""]];
+    const baseInputs = {
+      ...(definition ? definition.inputs : {}),
+      ...(building.inputs || {}),
+    };
+    const baseOutputs = {
+      ...(definition ? definition.outputs : {}),
+      ...(building.outputs || {}),
+    };
+    const currentReport =
+      building.productionReport && typeof building.productionReport === "object"
+        ? building.productionReport
+        : createReport("inactive", baseInputs, baseOutputs, "inactive", null);
+    const consumed = Object.keys(currentReport.consumed || {}).length
+      ? { ...currentReport.consumed }
+      : { ...baseInputs };
+    const produced = Object.keys(currentReport.produced || {}).length
+      ? { ...currentReport.produced }
+      : { ...baseOutputs };
+
+    if (building.built <= 0 || building.active <= 0) {
+      const detail = building.built <= 0 ? "not_built" : "no_workers";
+      building.productionReport = createReport("inactive", consumed, produced, "inactive", detail);
+      return;
+    }
+
+    if (currentReport.status === "stalled") {
+      building.productionReport = {
+        status: "stalled",
+        reason: currentReport.reason || "missing_input",
+        detail: currentReport.detail || null,
+        consumed,
+        produced,
+      };
+      return;
+    }
+
+    building.productionReport = createReport("produced", consumed, produced, "cycle_complete", null);
   }
 
   const buildingContainers = {
@@ -131,6 +365,10 @@
   const seasonLabel = document.getElementById("season-label");
   const seasonFill = document.getElementById("season-fill");
 
+  const buildingViews = new Map();
+  const jobViews = new Map();
+  const tradeViews = new Map();
+
   function getCapacity(building) {
     return building.built * building.capacityPerBuilding;
   }
@@ -139,6 +377,71 @@
     const buildingWorkers = state.buildings.reduce((total, building) => total + Number(building.active || 0), 0);
     const jobWorkers = state.jobs.reduce((total, job) => total + Number(job.assigned || 0), 0);
     return buildingWorkers + jobWorkers;
+  }
+
+  function countStalledBuildings() {
+    return state.buildings.reduce((total, building) => {
+      return building && building.productionReport && building.productionReport.status === "stalled"
+        ? total + 1
+        : total;
+    }, 0);
+  }
+
+  function formatNumber(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return "0";
+    }
+    const abs = Math.abs(numeric);
+    let maximumFractionDigits = 0;
+    if (abs < 1) {
+      maximumFractionDigits = 3;
+    } else if (abs < 10) {
+      maximumFractionDigits = 2;
+    } else if (abs < 100) {
+      maximumFractionDigits = 1;
+    }
+    return numeric.toLocaleString(undefined, { maximumFractionDigits });
+  }
+
+  function formatResourceName(key) {
+    if (!key) return "";
+    const lookup = resourceLabels[key];
+    if (lookup) return lookup;
+    const withSpaces = key.replace(/[_-]+/g, " ");
+    return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+  }
+
+  function normaliseIOEntries(record) {
+    if (!record) return [];
+    if (Array.isArray(record)) {
+      return record
+        .map((entry) => {
+          const key = entry?.resource || entry?.key;
+          const amount = Number(entry?.amount ?? entry?.value);
+          if (!key || !Number.isFinite(amount)) return null;
+          return { key: String(key), amount };
+        })
+        .filter(Boolean);
+    }
+    if (typeof record === "object") {
+      return Object.entries(record)
+        .map(([key, value]) => {
+          const amount = Number(value);
+          if (!Number.isFinite(amount)) return null;
+          return { key: String(key), amount };
+        })
+        .filter(Boolean);
+    }
+    return [];
+  }
+
+  function entriesToMap(entries) {
+    const map = new Map();
+    entries.forEach((entry) => {
+      map.set(String(entry.key), Number(entry.amount));
+    });
+    return map;
   }
 
   function updateChips() {
@@ -155,9 +458,12 @@
         case "population":
           valueSpan.textContent = `${assigned}/${state.population.total}`;
           break;
+        case "stalled":
+          valueSpan.textContent = String(countStalledBuildings());
+          break;
         default:
           if (state.resources[resourceKey] !== undefined) {
-            valueSpan.textContent = state.resources[resourceKey];
+            valueSpan.textContent = formatNumber(state.resources[resourceKey]);
           }
           break;
       }
@@ -198,28 +504,215 @@
     saveState();
   }
 
-  function renderBuildings() {
-    Object.values(buildingContainers).forEach((container) => {
-      if (container) container.innerHTML = "";
+  function updateIOList(container, cache, entries, options) {
+    if (!container) return;
+    const { prefix, baseClass, status, missingKey, role, reportMap, treatInactive = true, treatZero = true } = options;
+    const seen = new Set();
+    entries.forEach((entry) => {
+      const key = String(entry.key);
+      const amount = Number(entry.amount);
+      if (!Number.isFinite(amount)) return;
+      seen.add(key);
+      let pill = cache.get(key);
+      if (!pill) {
+        pill = document.createElement("span");
+        pill.dataset.resourceKey = key;
+        pill.className = `io-pill ${baseClass}`;
+        container.appendChild(pill);
+        cache.set(key, pill);
+      }
+      pill.className = `io-pill ${baseClass}`;
+      const displayAmount = Math.abs(amount);
+      const formattedAmount = formatNumber(displayAmount);
+      const resourceName = formatResourceName(key);
+      pill.textContent = `${prefix}${formattedAmount} ${resourceName}`;
+      const reportedAmount = reportMap && reportMap.has(key) ? Math.abs(reportMap.get(key)) : null;
+      const missing = Boolean(missingKey && missingKey === key);
+      const inactive = treatInactive && status !== "produced" && status !== "active";
+      const zeroOutput = treatZero && reportedAmount !== null && reportedAmount <= 0;
+      const shouldMarkInactive = !missing && (inactive || zeroOutput);
+      if (missing) {
+        pill.classList.add("io-pill--missing");
+      } else if (shouldMarkInactive) {
+        pill.classList.add("io-pill--inactive");
+      }
+      const ariaDisabled = missing || shouldMarkInactive;
+      pill.setAttribute("aria-disabled", ariaDisabled ? "true" : "false");
+      const actualAmount = reportedAmount !== null ? reportedAmount : displayAmount;
+      const baseLabel = `${role} ${formatNumber(actualAmount)} ${resourceName}`;
+      let ariaLabel = baseLabel;
+      if (missing) {
+        ariaLabel = `${baseLabel} (missing input)`;
+      } else if (shouldMarkInactive) {
+        ariaLabel = `${baseLabel} (inactive)`;
+      }
+      pill.setAttribute("aria-label", ariaLabel);
     });
+    cache.forEach((pill, key) => {
+      if (!seen.has(key)) {
+        pill.remove();
+        cache.delete(key);
+      }
+    });
+  }
 
-    state.buildings.forEach((building) => {
-      const container = buildingContainers[building.category];
-      if (!container) return;
-      const capacity = getCapacity(building);
-      const article = document.createElement("li");
-      article.innerHTML = `
+  function renderBuildingIO(view, building) {
+    if (!view) return;
+    const report = building.productionReport || createReport("inactive", building.inputs, building.outputs, "inactive", null);
+    const inputs = normaliseIOEntries(building.inputs);
+    const outputs = normaliseIOEntries(building.outputs);
+    const consumedMap = entriesToMap(normaliseIOEntries(report.consumed));
+    const producedMap = entriesToMap(normaliseIOEntries(report.produced));
+    const missingKey =
+      report.status === "stalled" && report.reason === "missing_input" && typeof report.detail === "string"
+        ? String(report.detail)
+        : null;
+    updateIOList(view.inputsContainer, view.inputPills, inputs, {
+      prefix: "−",
+      baseClass: "io-pill--input",
+      status: report.status,
+      missingKey,
+      role: "Consumes",
+      reportMap: consumedMap,
+      treatZero: true,
+    });
+    updateIOList(view.outputsContainer, view.outputPills, outputs, {
+      prefix: "+",
+      baseClass: "io-pill--output",
+      status: report.status,
+      missingKey: null,
+      role: "Produces",
+      reportMap: producedMap,
+      treatZero: true,
+    });
+  }
+
+  function updateBuildingStatus(view, building) {
+    if (!view) return;
+    const report = building.productionReport || createReport("inactive", building.inputs, building.outputs, "inactive", null);
+    const status = report.status || "inactive";
+    let label = "Inactive";
+    let detail = "";
+    if (status === "produced") {
+      label = "Producing";
+    } else if (status === "stalled") {
+      label = "Stalled";
+      if (report.reason === "missing_input" && report.detail) {
+        detail = `Missing ${formatResourceName(report.detail)}`;
+      } else if (report.reason === "no_capacity") {
+        detail = "Storage full";
+      } else if (report.detail) {
+        detail = String(report.detail);
+      }
+    } else {
+      if (building.built <= 0 || report.detail === "not_built") {
+        detail = "No structures built";
+      } else if (building.active <= 0 || report.detail === "no_workers") {
+        detail = "No workers assigned";
+      } else if (report.reason && report.reason !== "inactive") {
+        detail = formatResourceName(report.reason);
+      }
+    }
+    view.statusChip.textContent = label;
+    view.statusChip.className = "status-chip";
+    if (status === "stalled") {
+      view.statusChip.classList.add("status-chip--stalled");
+    } else if (status === "inactive") {
+      view.statusChip.classList.add("status-chip--inactive");
+    }
+    view.statusDetail.textContent = detail || "";
+    view.statusDetail.style.display = detail ? "inline" : "none";
+    view.card.classList.toggle("is-stalled", status === "stalled");
+    view.card.classList.toggle("is-inactive", status === "inactive");
+  }
+
+  function setButtonAccessibility(button, baseLabel, disabled, disabledReason) {
+    if (!button) return;
+    button.disabled = Boolean(disabled);
+    button.setAttribute("aria-disabled", disabled ? "true" : "false");
+    if (baseLabel) {
+      const finalLabel = disabled && disabledReason ? `${baseLabel} (disabled: ${disabledReason})` : baseLabel;
+      button.setAttribute("aria-label", finalLabel);
+    }
+  }
+
+  function setInputAccessibility(input, baseLabel, disabled, disabledReason) {
+    if (!input) return;
+    input.disabled = Boolean(disabled);
+    input.setAttribute("aria-disabled", disabled ? "true" : "false");
+    if (baseLabel) {
+      const finalLabel = disabled && disabledReason ? `${baseLabel} (disabled: ${disabledReason})` : baseLabel;
+      input.setAttribute("aria-label", finalLabel);
+    }
+  }
+
+  function updateBuildingControls(view, building) {
+    if (!view) return;
+    const capacity = getCapacity(building);
+    const totalAssigned = getTotalAssigned();
+    const assignedElsewhere = totalAssigned - building.active;
+    const available = Math.max(0, state.population.total - assignedElsewhere);
+    const freeWorkers = Math.max(0, available - building.active);
+    const remainingSlots = Math.max(0, capacity - building.active);
+    const canAssign = building.built > 0 && remainingSlots > 0 && freeWorkers > 0;
+    let assignReason = "";
+    if (building.built <= 0) {
+      assignReason = "No buildings constructed";
+    } else if (remainingSlots <= 0) {
+      assignReason = "Capacity reached";
+    } else if (freeWorkers <= 0) {
+      assignReason = "No available villagers";
+    }
+    setButtonAccessibility(view.buildButton, `Build ${building.name}`, false);
+    setButtonAccessibility(
+      view.demolishButton,
+      `Demolish ${building.name}`,
+      building.built <= 0,
+      building.built <= 0 ? "No structures to demolish" : ""
+    );
+    setButtonAccessibility(view.assignButton, `Assign workers to ${building.name}`, !canAssign, assignReason || "");
+    const disableInput = building.built <= 0;
+    setInputAccessibility(view.assignInput, `${building.name} workers`, disableInput, "No buildings constructed");
+    if (!disableInput) {
+      view.assignInput.max = capacity;
+    }
+  }
+
+  function ensureBuildingView(building) {
+    if (!building) return null;
+    let view = buildingViews.get(building.id);
+    const categoryKey = building.category || (buildingCatalog[building.type]?.category ?? "wood");
+    const container = buildingContainers[categoryKey];
+    if (!container) return null;
+    if (!view) {
+      const listItem = document.createElement("li");
+      listItem.dataset.buildingId = building.id;
+      listItem.innerHTML = `
         <article class="building-card" data-building-id="${building.id}">
-          <span class="icon-badge" role="img" aria-label="${building.name} icon">${building.icon}</span>
+          <span class="icon-badge" role="img" aria-label="${building.name} icon"></span>
           <div class="building-meta">
             <div class="flex items-start justify-between gap-2">
-              <h3 class="text-base font-semibold text-slate-100">${building.name}</h3>
-              <span class="text-[0.65rem] uppercase tracking-[0.2em] text-slate-500">${building.category}</span>
+              <h3 class="text-base font-semibold text-slate-100" data-field="name"></h3>
+              <span class="text-[0.65rem] uppercase tracking-[0.2em] text-slate-500" data-field="category"></span>
             </div>
             <div class="stat-row">
-              <span>Built <strong>${building.built}</strong></span>
-              <span>Active <strong>${building.active}</strong></span>
-              <span>Capacity <strong>${capacity}</strong></span>
+              <span>Built <strong data-field="built"></strong></span>
+              <span>Active <strong data-field="active"></strong></span>
+              <span>Capacity <strong data-field="capacity"></strong></span>
+            </div>
+            <div class="io-grid">
+              <div class="io-column">
+                <span class="io-title">Consumes</span>
+                <div class="io-pills" data-io-inputs></div>
+              </div>
+              <div class="io-column">
+                <span class="io-title">Produces</span>
+                <div class="io-pills" data-io-outputs></div>
+              </div>
+            </div>
+            <div class="status-row" data-status-row>
+              <span class="status-chip status-chip--inactive" data-status-chip>Inactive</span>
+              <span class="status-detail" data-status-detail></span>
             </div>
             <div class="bar" aria-hidden="true"></div>
             <div class="action-row">
@@ -227,70 +720,244 @@
               <button type="button" data-action="demolish" data-building-id="${building.id}">Demolish</button>
               <label class="flex items-center gap-2 text-xs text-slate-300">
                 <span>Workers</span>
-                <input type="number" min="0" step="1" value="${building.active}" data-building-input="${building.id}" />
+                <input type="number" min="0" step="1" data-building-input="${building.id}" />
               </label>
               <button type="button" data-action="assign" data-building-id="${building.id}">Assign</button>
             </div>
           </div>
         </article>
       `;
-      container.appendChild(article);
+      container.appendChild(listItem);
+      const card = listItem.querySelector(".building-card");
+      view = {
+        root: listItem,
+        card,
+        icon: card.querySelector(".icon-badge"),
+        name: card.querySelector('[data-field="name"]'),
+        category: card.querySelector('[data-field="category"]'),
+        builtValue: card.querySelector('[data-field="built"]'),
+        activeValue: card.querySelector('[data-field="active"]'),
+        capacityValue: card.querySelector('[data-field="capacity"]'),
+        statusChip: card.querySelector('[data-status-chip]'),
+        statusDetail: card.querySelector('[data-status-detail]'),
+        inputsContainer: card.querySelector('[data-io-inputs]'),
+        outputsContainer: card.querySelector('[data-io-outputs]'),
+        buildButton: card.querySelector('button[data-action="build"]'),
+        demolishButton: card.querySelector('button[data-action="demolish"]'),
+        assignButton: card.querySelector('button[data-action="assign"]'),
+        assignInput: card.querySelector(`input[data-building-input="${building.id}"]`),
+        inputPills: new Map(),
+        outputPills: new Map(),
+      };
+      buildingViews.set(building.id, view);
+    }
+    if (view.root.parentElement !== container) {
+      container.appendChild(view.root);
+    }
+    return view;
+  }
+
+  function updateBuildingView(view, building) {
+    if (!view) return;
+    view.icon.textContent = building.icon;
+    view.icon.setAttribute("aria-label", `${building.name} icon`);
+    view.name.textContent = building.name;
+    view.category.textContent = building.category;
+    view.builtValue.textContent = formatNumber(building.built);
+    view.activeValue.textContent = formatNumber(building.active);
+    view.capacityValue.textContent = formatNumber(getCapacity(building));
+    if (document.activeElement !== view.assignInput) {
+      view.assignInput.value = building.active;
+    }
+    renderBuildingIO(view, building);
+    updateBuildingStatus(view, building);
+    updateBuildingControls(view, building);
+  }
+
+  function renderBuildings() {
+    const seen = new Set();
+    state.buildings.forEach((building) => {
+      updateBuildingReportFromState(building);
+      const view = ensureBuildingView(building);
+      if (!view) return;
+      seen.add(building.id);
+      updateBuildingView(view, building);
+    });
+    buildingViews.forEach((view, key) => {
+      if (!seen.has(key)) {
+        if (view.root.parentElement) {
+          view.root.parentElement.removeChild(view.root);
+        }
+        buildingViews.delete(key);
+      }
     });
   }
 
-  function renderJobs() {
-    jobsList.innerHTML = "";
-    state.jobs.forEach((job) => {
+  function ensureJobView(job) {
+    if (!job) return null;
+    let view = jobViews.get(job.id);
+    if (!view) {
       const card = document.createElement("div");
       card.className = "job-card";
       card.dataset.jobId = job.id;
       card.innerHTML = `
         <header>
           <div class="flex items-center gap-2 text-slate-100">
-            <span class="icon-badge icon-badge--sm" role="img" aria-label="${job.name} icon">${job.icon}</span>
-            <span>${job.name}</span>
+            <span class="icon-badge icon-badge--sm" role="img" aria-label="${job.name} icon"></span>
+            <span data-field="name"></span>
           </div>
-          <span class="text-xs uppercase tracking-[0.2em] text-slate-400">${job.assigned}/${job.max}</span>
+          <span class="text-xs uppercase tracking-[0.2em] text-slate-400" data-field="count"></span>
         </header>
         <div class="controls">
           <button type="button" data-action="job-decrement" data-job-id="${job.id}">-</button>
-          <input type="number" min="0" max="${job.max}" value="${job.assigned}" data-job-input="${job.id}" />
+          <input type="number" min="0" data-job-input="${job.id}" />
           <button type="button" data-action="job-increment" data-job-id="${job.id}">+</button>
         </div>
       `;
       jobsList.appendChild(card);
+      view = {
+        root: card,
+        icon: card.querySelector(".icon-badge"),
+        name: card.querySelector('[data-field="name"]'),
+        count: card.querySelector('[data-field="count"]'),
+        decrement: card.querySelector('button[data-action="job-decrement"]'),
+        increment: card.querySelector('button[data-action="job-increment"]'),
+        input: card.querySelector(`input[data-job-input="${job.id}"]`),
+      };
+      jobViews.set(job.id, view);
+    }
+    if (view.root.parentElement !== jobsList) {
+      jobsList.appendChild(view.root);
+    }
+    return view;
+  }
+
+  function updateJobView(view, job) {
+    if (!view) return;
+    view.icon.textContent = job.icon || "";
+    view.icon.setAttribute("aria-label", `${job.name} icon`);
+    view.name.textContent = job.name;
+    view.count.textContent = `${job.assigned}/${job.max}`;
+    view.input.max = job.max;
+    if (document.activeElement !== view.input) {
+      view.input.value = job.assigned;
+    }
+    setInputAccessibility(view.input, `${job.name} workers`, false, "");
+    const otherAssigned = getTotalAssigned() - job.assigned;
+    const available = Math.max(0, state.population.total - otherAssigned);
+    const freeWorkers = Math.max(0, available - job.assigned);
+    const canDecrease = job.assigned > 0;
+    const canIncrease = job.assigned < job.max && freeWorkers > 0;
+    const increaseReason =
+      job.assigned >= job.max
+        ? "Max capacity reached"
+        : freeWorkers <= 0
+        ? "No available villagers"
+        : "";
+    setButtonAccessibility(view.decrement, `Decrease ${job.name} workers`, !canDecrease, "No workers assigned");
+    setButtonAccessibility(view.increment, `Increase ${job.name} workers`, !canIncrease, increaseReason);
+  }
+
+  function renderJobs() {
+    const seen = new Set();
+    state.jobs.forEach((job) => {
+      const view = ensureJobView(job);
+      if (!view) return;
+      seen.add(job.id);
+      updateJobView(view, job);
+    });
+    jobViews.forEach((view, key) => {
+      if (!seen.has(key)) {
+        if (view.root.parentElement) {
+          view.root.parentElement.removeChild(view.root);
+        }
+        jobViews.delete(key);
+      }
     });
   }
 
-  function renderTrade() {
-    tradeList.innerHTML = "";
-    state.trade.forEach((item) => {
-      const balance = item.export - item.import;
+  function ensureTradeView(item) {
+    if (!item) return null;
+    let view = tradeViews.get(item.id);
+    if (!view) {
       const row = document.createElement("div");
       row.className = "trade-row";
       row.dataset.tradeId = item.id;
       row.innerHTML = `
         <div class="flex items-center gap-3 text-sm font-semibold text-slate-100">
-          <span class="icon-badge icon-badge--sm" role="img" aria-label="${item.label} icon">${item.icon}</span>
-          <span>${item.label}</span>
+          <span class="icon-badge icon-badge--sm" role="img" aria-label="${item.label} icon"></span>
+          <span data-field="label"></span>
         </div>
         <div class="controls">
           <button type="button" class="export" data-action="trade-export" data-trade-id="${item.id}">Export</button>
           <button type="button" class="import" data-action="trade-import" data-trade-id="${item.id}">Import</button>
           <label class="flex flex-1 items-center gap-2 text-xs text-slate-300">
             <span>Export</span>
-            <input type="range" min="0" max="100" step="1" value="${item.export}" data-trade-slider="${item.id}" />
+            <input type="range" min="0" max="100" step="1" data-trade-slider="${item.id}" />
           </label>
           <label class="flex items-center gap-2 text-xs text-slate-300">
             <span>Import</span>
-            <input type="number" min="0" step="1" value="${item.import}" data-trade-input="${item.id}" />
+            <input type="number" min="0" step="1" data-trade-input="${item.id}" />
           </label>
         </div>
-        <div class="balance ${balance > 0 ? "positive" : balance < 0 ? "negative" : ""}">
-          Balance ${balance > 0 ? "+" : ""}${balance}
-        </div>
+        <div class="balance" data-field="balance"></div>
       `;
       tradeList.appendChild(row);
+      view = {
+        root: row,
+        icon: row.querySelector(".icon-badge"),
+        label: row.querySelector('[data-field="label"]'),
+        exportButton: row.querySelector("button.export"),
+        importButton: row.querySelector("button.import"),
+        slider: row.querySelector(`input[data-trade-slider="${item.id}"]`),
+        input: row.querySelector(`input[data-trade-input="${item.id}"]`),
+        balance: row.querySelector('[data-field="balance"]'),
+      };
+      tradeViews.set(item.id, view);
+    }
+    if (view.root.parentElement !== tradeList) {
+      tradeList.appendChild(view.root);
+    }
+    return view;
+  }
+
+  function updateTradeView(view, item) {
+    if (!view) return;
+    view.icon.textContent = item.icon || "";
+    view.icon.setAttribute("aria-label", `${item.label} icon`);
+    view.label.textContent = item.label;
+    if (document.activeElement !== view.slider) {
+      view.slider.value = item.export;
+    }
+    if (document.activeElement !== view.input) {
+      view.input.value = item.import;
+    }
+    view.slider.setAttribute("aria-label", `${item.label} export preference`);
+    view.input.setAttribute("aria-label", `${item.label} import quantity`);
+    setButtonAccessibility(view.exportButton, `Increase ${item.label} exports`, false);
+    setButtonAccessibility(view.importButton, `Increase ${item.label} imports`, false);
+    const balance = Number(item.export) - Number(item.import);
+    const formattedBalance = formatNumber(balance);
+    view.balance.textContent = `Balance ${balance > 0 ? "+" : ""}${formattedBalance}`;
+    view.balance.classList.toggle("positive", balance > 0);
+    view.balance.classList.toggle("negative", balance < 0);
+  }
+
+  function renderTrade() {
+    const seen = new Set();
+    state.trade.forEach((item) => {
+      const view = ensureTradeView(item);
+      if (!view) return;
+      seen.add(item.id);
+      updateTradeView(view, item);
+    });
+    tradeViews.forEach((view, key) => {
+      if (!seen.has(key)) {
+        if (view.root.parentElement) {
+          view.root.parentElement.removeChild(view.root);
+        }
+        tradeViews.delete(key);
+      }
     });
   }
 
@@ -304,14 +971,15 @@
   function adjustBuildingCount(buildingId, delta) {
     const building = state.buildings.find((entry) => entry.id === buildingId);
     if (!building) return;
-    const nextBuilt = Math.max(0, building.built + delta);
-    building.built = nextBuilt;
+    building.built = Math.max(0, Number(building.built || 0) + Number(delta || 0));
     const capacity = getCapacity(building);
     if (building.active > capacity) {
       building.active = capacity;
     }
+    updateBuildingReportFromState(building);
     saveState();
     renderBuildings();
+    renderJobs();
     updateJobsCount();
   }
 
@@ -324,8 +992,10 @@
     const available = Math.max(0, state.population.total - assignedElsewhere);
     const finalValue = Math.min(sanitized, available);
     building.active = finalValue;
+    updateBuildingReportFromState(building);
     saveState();
     renderBuildings();
+    renderJobs();
     updateJobsCount();
   }
 
@@ -334,7 +1004,7 @@
     if (!job) return;
     const otherAssigned = getTotalAssigned() - job.assigned;
     const available = Math.max(0, state.population.total - otherAssigned);
-    const desired = job.assigned + delta;
+    const desired = Number(job.assigned || 0) + Number(delta || 0);
     const limited = Math.min(job.max, Math.max(0, desired));
     job.assigned = Math.min(limited, available);
     saveState();
@@ -365,6 +1035,74 @@
     }
     saveState();
     renderTrade();
+  }
+
+  function mergeProductionReports(reports) {
+    if (!reports || typeof reports !== "object") return;
+    const reportMap = new Map();
+    if (Array.isArray(reports)) {
+      reports.forEach((entry) => {
+        if (!entry) return;
+        const key =
+          entry.id != null
+            ? String(entry.id)
+            : entry.building_id != null
+            ? String(entry.building_id)
+            : entry.slug || entry.type || null;
+        if (!key) return;
+        reportMap.set(String(key), entry);
+      });
+    } else {
+      Object.entries(reports).forEach(([key, value]) => {
+        if (!value) return;
+        reportMap.set(String(key), value);
+      });
+    }
+    state.buildings.forEach((building) => {
+      const keysToCheck = [String(building.id), building.type, building.slug];
+      let reportData = null;
+      for (const candidate of keysToCheck) {
+        if (candidate && reportMap.has(candidate)) {
+          reportData = reportMap.get(candidate);
+          break;
+        }
+      }
+      if (reportData) {
+        building.productionReport = createReport(
+          reportData.status,
+          reportData.consumed || reportData.inputs,
+          reportData.produced || reportData.outputs,
+          reportData.reason,
+          reportData.detail
+        );
+      }
+      updateBuildingReportFromState(building);
+    });
+  }
+
+  function mergeBuildingSnapshots(buildingsSnapshot) {
+    if (!Array.isArray(buildingsSnapshot)) return;
+    state.buildings = buildingsSnapshot
+      .map((entry) => normaliseBuildingEntry(entry))
+      .filter(Boolean);
+  }
+
+  function handleServerPayload(payload) {
+    if (!payload || typeof payload !== "object") return;
+    if (payload.season) {
+      updateSeasonState(payload.season);
+    }
+    if (Array.isArray(payload.buildings)) {
+      mergeBuildingSnapshots(payload.buildings);
+    }
+    if (payload.production_report) {
+      mergeProductionReports(payload.production_report);
+    }
+    renderBuildings();
+    renderJobs();
+    updateJobsCount();
+    renderTrade();
+    saveState();
   }
 
   function handleBuildingActions(event) {
@@ -459,8 +1197,8 @@
 
   async function loadSeasonFromStateEndpoint() {
     const payload = await fetchJson("/api/state");
-    if (payload && payload.season) {
-      updateSeasonState(payload.season);
+    if (payload) {
+      handleServerPayload(payload);
       return true;
     }
     return false;
@@ -472,8 +1210,8 @@
       return;
     }
     const initPayload = await fetchJson("/api/init", { method: "POST" });
-    if (initPayload && initPayload.season) {
-      updateSeasonState(initPayload.season);
+    if (initPayload) {
+      handleServerPayload(initPayload);
     }
     await loadSeasonFromStateEndpoint();
   }
@@ -491,8 +1229,8 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ dt: 1 }),
       });
-      if (payload && payload.season) {
-        updateSeasonState(payload.season);
+      if (payload) {
+        handleServerPayload(payload);
       }
       ticking = false;
     };

--- a/static/styles.css
+++ b/static/styles.css
@@ -162,10 +162,124 @@ body {
   box-shadow: 0 15px 35px -25px rgb(8 15 30 / 0.8);
 }
 
+.building-card.is-stalled {
+  border-color: rgb(248 113 113 / 0.55);
+  box-shadow: 0 20px 45px -25px rgb(248 113 113 / 0.35);
+}
+
+.building-card.is-inactive {
+  border-color: rgb(71 85 105 / 0.6);
+  background: rgb(15 23 42 / 0.45);
+}
+
 .building-meta {
   display: grid;
   gap: 0.35rem;
   font-size: 0.875rem;
+}
+
+.io-grid {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  margin-top: 0.35rem;
+}
+
+.io-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.io-title {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgb(148 163 184 / 0.9);
+}
+
+.io-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.io-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  border: 1px solid rgb(51 65 85 / 0.8);
+  background: rgb(30 41 59 / 0.65);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgb(226 232 240);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.io-pill--input {
+  background: rgb(30 41 59 / 0.5);
+}
+
+.io-pill--output {
+  background: rgb(17 24 39 / 0.55);
+  border-color: rgb(94 234 212 / 0.35);
+  color: rgb(165 243 252);
+}
+
+.io-pill--missing {
+  border-color: rgb(248 113 113 / 0.45);
+  background: rgb(248 113 113 / 0.12);
+  color: rgb(254 226 226);
+}
+
+.io-pill--inactive {
+  border-color: rgb(71 85 105 / 0.5);
+  background: rgb(30 41 59 / 0.35);
+  color: rgb(148 163 184);
+}
+
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: rgb(148 163 184);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  padding: 0.25rem 0.6rem;
+  background: rgb(30 41 59 / 0.6);
+  border: 1px solid rgb(51 65 85 / 0.7);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(226 232 240 / 0.85);
+}
+
+.status-chip--stalled {
+  background: rgb(248 113 113 / 0.18);
+  border-color: rgb(248 113 113 / 0.45);
+  color: rgb(254 226 226);
+}
+
+.status-chip--inactive {
+  background: rgb(71 85 105 / 0.2);
+  border-color: rgb(71 85 105 / 0.45);
+  color: rgb(203 213 225);
+}
+
+.status-detail {
+  color: rgb(148 163 184 / 0.85);
 }
 
 .stat-row {

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <div class="grid grid-cols-2 gap-3 mt-4 sm:grid-cols-4 lg:grid-cols-8">
       <div class="chip" data-resource="happiness">😊 Happiness <span class="value">82%</span></div>
       <div class="chip" data-resource="population">👤 Population <span class="value">15</span></div>
+      <div class="chip" data-resource="stalled">⏸️ Stalled <span class="value">0</span></div>
       <div class="chip" data-resource="gold">🪙 Gold <span class="value">320</span></div>
       <div class="chip" data-resource="wood">🪵 Wood <span class="value">210</span></div>
       <div class="chip" data-resource="planks">🧱 Planks <span class="value">46</span></div>


### PR DESCRIPTION
## Summary
- add a stalled status chip to the dashboard header and style building IO/status elements to match existing cards
- normalise building metadata and production reports to support in-place DOM updates with IO pills, status chips, and accessible control states
- integrate server payload handling for building reports so periodic ticks refresh UI sections without flicker

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de04da8fac83329957f21610fd08c4