### PR TITLE
Add aria attributes to IO pills and disabled controls

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -231,9 +231,20 @@ body {
     color 0.2s ease, opacity 0.2s ease;
 }
 
-.status-chip__action:disabled {
+.status-chip__action:disabled,
+.status-chip__action[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.action-row button:disabled,
+.action-row button[aria-disabled="true"],
+.job-card button:disabled,
+.job-card button[aria-disabled="true"],
+.worker-controls button:disabled,
+.worker-controls button[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .status-chip--warning .status-chip__action:not(:disabled) {


### PR DESCRIPTION
## Summary
- add an aria-disabled sync helper to buttons so disabled worker controls and status actions expose their state
- surface aria-labels on IO pills using their descriptive titles for screen reader context and add styling coverage for aria-disabled buttons

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de911d086883329db1149b359fd84d