### PR TITLE
Reset initial state to woodcutter baseline

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Mapping, Optional
+from typing import Dict, Mapping, Optional, Tuple
 
 from .resources import ALL_RESOURCES, Resource, normalise_mapping
 
@@ -138,7 +138,10 @@ CAPACIDADES: Dict[Resource, float] = {
 WORKERS_INICIALES: int = 20
 
 STARTING_RESOURCES: Dict[Resource, float] = {resource: 0.0 for resource in ALL_RESOURCES}
-STARTING_RESOURCES[Resource.GOLD] = 10.0
+
+STARTING_BUILDINGS: Tuple[Mapping[str, object], ...] = (
+    {"type": WOODCUTTER_CAMP, "workers": 0, "enabled": True},
+)
 
 SEASON_MODIFIERS: Dict[str, Dict[str, float]] = {
     "Spring": {

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -66,6 +66,7 @@ def load_game(path: str) -> None:
     game_state.worker_pool.set_total_workers(int(workers_info.get("total", game_state.worker_pool.total_workers)))
 
     game_state.buildings = {}
+    game_state.worker_pool.bulk_load_assignments({})
     Building.reset_ids()
     max_id = 0
     for entry in data.get("buildings", []):

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,14 +12,14 @@
       </div>
     </div>
     <div class="grid grid-cols-2 gap-3 mt-4 sm:grid-cols-4 lg:grid-cols-8">
-      <div class="chip" data-resource="happiness">😊 Happiness <span class="value">82%</span></div>
-      <div class="chip" data-resource="population">👤 Population <span class="value">15</span></div>
-      <div class="chip" data-resource="gold">🪙 Gold <span class="value">320</span></div>
-      <div class="chip" data-resource="wood">🪵 Wood <span class="value">210</span></div>
-      <div class="chip" data-resource="planks">🧱 Planks <span class="value">46</span></div>
-      <div class="chip" data-resource="stone">🪨 Stone <span class="value">138</span></div>
-      <div class="chip" data-resource="tools">🛠️ Tools <span class="value">12</span></div>
-      <div class="chip" data-resource="wheat">🌾 Wheat <span class="value">75</span></div>
+      <div class="chip" data-resource="happiness">😊 Happiness <span class="value">0%</span></div>
+      <div class="chip" data-resource="population">👤 Population <span class="value">0/20</span></div>
+      <div class="chip" data-resource="gold">🪙 Gold <span class="value">0</span></div>
+      <div class="chip" data-resource="wood">🪵 Wood <span class="value">0</span></div>
+      <div class="chip" data-resource="planks">🧱 Planks <span class="value">0</span></div>
+      <div class="chip" data-resource="stone">🪨 Stone <span class="value">0</span></div>
+      <div class="chip" data-resource="tools">🛠️ Tools <span class="value">0</span></div>
+      <div class="chip" data-resource="wheat">🌾 Wheat <span class="value">0</span></div>
     </div>
   </div>
 </header>
@@ -73,7 +73,7 @@
       <section class="panel" id="jobs">
         <div class="panel-header justify-between">
           <div>
-            <h2 class="panel-title">Jobs <span id="jobs-count">15/20</span> 👤</h2>
+            <h2 class="panel-title">Jobs <span id="jobs-count">0/20</span> 👤</h2>
           </div>
           <div class="relative group">
             <button class="tooltip-trigger" type="button">Costs</button>


### PR DESCRIPTION
## Summary
- reset all starting resources and introduce a configurable list of starting buildings seeded with a single woodcutter camp
- update game state snapshots and persistence to initialise and report the new baseline, and expose resource totals through the API
- refresh the frontend defaults, reset handling, and tests so the UI and backend begin at zero with only the woodcutter available

## Testing
- python tests/test_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68de9f00e6ec8332a8dad4f5407eb3ca