### PR TITLE
Ensure wood production and initial state reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Flask, jsonify, render_template, request
 
 from api import ui_bridge
@@ -5,6 +7,8 @@ from core.scheduler import ensure_tick_loop
 
 app = Flask(__name__)
 ensure_tick_loop()
+
+logger = logging.getLogger(__name__)
 
 
 @app.route("/")
@@ -18,7 +22,13 @@ def public_state():
     """Expose the minimal public state payload required by the frontend."""
 
     payload = ui_bridge.get_basic_state()
-    return jsonify(payload)
+    wood_amount = payload.get("items", {}).get("wood")
+    logger.info("/state payload wood=%.1f", wood_amount if wood_amount is not None else 0.0)
+    response = jsonify(payload)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
 
 
 @app.post("/api/init")

--- a/core/config.py
+++ b/core/config.py
@@ -135,7 +135,11 @@ CAPACIDADES: Dict[Resource, float] = {
     Resource.HOPS: 200,
 }
 
-WORKERS_INICIALES: int = 20
+# Population configuration
+POPULATION_INITIAL: int = 2
+POPULATION_CAPACITY: int = 20
+
+WORKERS_INICIALES: int = POPULATION_INITIAL
 
 STARTING_RESOURCES: Dict[Resource, float] = {resource: 0.0 for resource in ALL_RESOURCES}
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -29,6 +29,15 @@ def _assign_workers(count: int) -> None:
     ui_bridge.assign_workers(building.id, count)
 
 
+def test_basic_state_snapshot_defaults():
+    state = get_game_state()
+    snapshot = state.basic_state_snapshot()
+    assert snapshot["population"] == {"current": 2, "capacity": 20}
+    assert snapshot["buildings"][config.WOODCUTTER_CAMP]["workers"] == 0
+    for key, amount in snapshot["items"].items():
+        assert amount == pytest.approx(0.0), f"{key} expected to be 0"
+
+
 def test_initial_wood_is_zero():
     assert _get_wood_amount() == 0.0
 


### PR DESCRIPTION
## Summary
- ensure population defaults, logging, and no-cache headers around the public state endpoint
- normalise wood/resource snapshots to 1 decimal with population tracking and periodic tick diagnostics
- refresh the frontend to respect the new population model, stabilise wood polling, and extend backend tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df19079f70833287c08f12fba16dbf