### PR TITLE
Synchronize woodcutter assignments and wood production

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Dict
 
 from core.game_state import get_game_state
+from core.jobs import WorkerAllocationError
 from core.persistence import load_game as core_load_game, save_game as core_save_game
 from core.resources import Resource
 
@@ -164,10 +165,13 @@ def _mutate_workers(building_id: int, num: int, *, operation: str) -> Dict[str, 
             key: changed,
             "building": snapshot,
             "production_report": snapshot["last_report"],
+            "state": state.basic_state_snapshot(),
         }
         if operation == "assign" and changed < num:
             payload["warning"] = "No se pudieron asignar todos los trabajadores"
         return _success_response(**payload)
+    except WorkerAllocationError as exc:
+        return _error_response("assignment_failed", str(exc))
     except ValueError as exc:
         return _error_response("building_not_found", str(exc))
 

--- a/app.py
+++ b/app.py
@@ -79,5 +79,22 @@ def api_assign_workers(building_id: int):
     return jsonify(response)
 
 
+@app.post("/api/buildings/<int:building_id>/unassign")
+def api_unassign_workers(building_id: int):
+    """Unassign workers from a building using the bridge helper."""
+
+    payload = request.get_json(silent=True) or {}
+    requested = (
+        payload.get("workers")
+        if payload.get("workers") is not None
+        else payload.get("count")
+    )
+    if requested is None:
+        requested = payload.get("unassign") or payload.get("number")
+
+    response = ui_bridge.unassign_workers(building_id, requested or 0)
+    return jsonify(response)
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -386,6 +386,7 @@ class Building:
             "name": self.name,
             "built": self.built,
             "active_workers": self.assigned_workers,
+            "workers": self.assigned_workers,
             "max_workers": self.max_workers,
             "inputs": {res.value: amt for res, amt in self.inputs_per_cycle.items()},
             "outputs": {res.value: amt for res, amt in self.outputs_per_cycle.items()},

--- a/core/jobs.py
+++ b/core/jobs.py
@@ -6,27 +6,41 @@ from typing import Dict
 from .buildings import Building
 
 
+class WorkerAllocationError(Exception):
+    """Raised when a worker assignment request cannot be fulfilled."""
+
+
 class WorkerPool:
     """Controls worker assignments across buildings."""
 
     def __init__(self, total_workers: int) -> None:
         self.total_workers = total_workers
-        self._assignments: Dict[int, int] = {}
+        self._buildings: Dict[int, Building] = {}
 
     # ------------------------------------------------------------------
     @property
     def available_workers(self) -> int:
-        assigned = sum(self._assignments.values())
+        assigned = sum(
+            max(0, building.assigned_workers) for building in self._buildings.values()
+        )
         return max(0, self.total_workers - assigned)
 
     def register_building(self, building: Building) -> None:
-        self._assignments.setdefault(building.id, building.assigned_workers)
+        self._buildings[building.id] = building
 
     def unregister_building(self, building_id: int) -> int:
-        return self._assignments.pop(building_id, 0)
+        building = self._buildings.pop(building_id, None)
+        if building is None:
+            return 0
+        removed = max(0, building.assigned_workers)
+        building.assigned_workers = 0
+        return removed
 
     def get_assignment(self, building_id: int) -> int:
-        return self._assignments.get(building_id, 0)
+        building = self._buildings.get(building_id)
+        if building is None:
+            return 0
+        return max(0, building.assigned_workers)
 
     # ------------------------------------------------------------------
     def assign_workers(self, building: Building, number: int) -> int:
@@ -35,13 +49,16 @@ class WorkerPool:
         self.register_building(building)
         room = building.max_workers - building.assigned_workers
         if room <= 0:
-            return 0
-        allowed = min(number, room, self.available_workers)
-        if allowed <= 0:
-            return 0
-        building.assigned_workers += allowed
-        self._assignments[building.id] = building.assigned_workers
-        return allowed
+            raise WorkerAllocationError("Capacidad máxima del edificio alcanzada")
+        available = self.available_workers
+        if available <= 0:
+            raise WorkerAllocationError("No hay población disponible")
+        if number > available:
+            raise WorkerAllocationError("No hay suficientes trabajadores disponibles")
+        if number > room:
+            raise WorkerAllocationError("Capacidad máxima del edificio alcanzada")
+        building.assigned_workers += number
+        return number
 
     def unassign_workers(self, building: Building, number: int) -> int:
         if number <= 0:
@@ -51,26 +68,35 @@ class WorkerPool:
         if removed <= 0:
             return 0
         building.assigned_workers = max(0, building.assigned_workers - removed)
-        self._assignments[building.id] = building.assigned_workers
         return removed
 
     def set_assignment(self, building: Building, number: int) -> None:
         value = max(0, min(int(number), building.max_workers))
+        self.register_building(building)
         building.assigned_workers = value
-        self._assignments[building.id] = value
 
     # ------------------------------------------------------------------
     def snapshot(self) -> Dict[int, Dict[str, int]]:
         return {
-            building_id: {"assigned": assigned}
-            for building_id, assigned in self._assignments.items()
+            building_id: {"assigned": max(0, building.assigned_workers)}
+            for building_id, building in self._buildings.items()
         }
 
     def set_total_workers(self, total: int) -> None:
         self.total_workers = max(0, total)
 
     def bulk_load_assignments(self, assignments: Dict[int, int]) -> None:
-        self._assignments = {int(k): int(v) for k, v in assignments.items()}
+        if not assignments:
+            self._buildings = {}
+            return
+        for building_id, value in assignments.items():
+            building = self._buildings.get(int(building_id))
+            if building is None:
+                continue
+            self.set_assignment(building, int(value))
 
     def bulk_export_assignments(self) -> Dict[int, int]:
-        return dict(self._assignments)
+        return {
+            building_id: max(0, building.assigned_workers)
+            for building_id, building in self._buildings.items()
+        }

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -26,7 +26,8 @@ def _assign_workers(count: int) -> None:
     state = get_game_state()
     building = state.get_building_by_type(config.WOODCUTTER_CAMP)
     assert building is not None
-    ui_bridge.assign_workers(building.id, count)
+    response = ui_bridge.assign_workers(building.id, count)
+    assert response["ok"] is True, response
 
 
 def test_basic_state_snapshot_defaults():
@@ -65,7 +66,13 @@ def test_wood_increases_by_point_one_per_second_with_workers():
 
 
 def test_additional_workers_do_not_change_generation_rate():
-    _assign_workers(3)
+    state = get_game_state()
+    building = state.get_building_by_type(config.WOODCUTTER_CAMP)
+    assert building is not None
+    failure = ui_bridge.assign_workers(building.id, 3)
+    assert failure["ok"] is False
+    assert failure.get("error_code") == "assignment_failed"
+    _assign_workers(2)
     state = get_game_state()
     for _ in range(5):
         state.tick(1.0)


### PR DESCRIPTION
## Summary
- make the worker pool derive assignments from buildings and raise explicit errors when capacity or population limits are exceeded
- bump the game state's version and wood tick logic so /state exposes aligned building, job, population, and wood data
- return updated state snapshots from the worker mutation API and add an unassign route
- update the frontend to serialize assignment requests, ignore stale payloads via version tracking, and map job controls to building assignments
- extend backend tests to cover assignment failures

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68df21f215448332b94f5a85b2699b7e