### PR TITLE
Enable building-based worker assignment

### DIFF
--- a/core/game_state.py
+++ b/core/game_state.py
@@ -398,7 +398,9 @@ class GameState:
         with self._lock:
             current = int(self.population_current)
             capacity = int(self.population_capacity)
-        return {"current": current, "capacity": capacity}
+            available = int(self.worker_pool.available_workers)
+        available = max(0, min(current, available))
+        return {"current": current, "capacity": capacity, "available": available}
 
     def snapshot_trade(self) -> Dict[str, Dict[str, float | str]]:
         return self.trade_manager.snapshot()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -33,7 +33,7 @@ def _assign_workers(count: int) -> None:
 def test_basic_state_snapshot_defaults():
     state = get_game_state()
     snapshot = state.basic_state_snapshot()
-    assert snapshot["population"] == {"current": 2, "capacity": 20}
+    assert snapshot["population"] == {"current": 2, "capacity": 20, "available": 2}
     building_payload = snapshot["buildings"][config.WOODCUTTER_CAMP]
     assert building_payload == {
         "built": 1,
@@ -87,3 +87,14 @@ def test_jobs_reflect_building_assignments():
     snapshot = state.basic_state_snapshot()
     assert snapshot["buildings"][config.WOODCUTTER_CAMP]["workers"] == 2
     assert snapshot["jobs"]["forester"]["assigned"] == 2
+    assert snapshot["population"]["available"] == 0
+
+
+def test_population_pool_recovers_after_unassign():
+    state = get_game_state()
+    building = state.get_building_by_type(config.WOODCUTTER_CAMP)
+    assert building is not None
+    ui_bridge.assign_workers(building.id, 1)
+    ui_bridge.unassign_workers(building.id, 1)
+    snapshot = state.basic_state_snapshot()
+    assert snapshot["population"] == {"current": 2, "capacity": 20, "available": 2}

--- a/tests/test_e2e_init.py
+++ b/tests/test_e2e_init.py
@@ -87,6 +87,9 @@ def test_forced_init_and_first_production_cycle(client):
     assert assign_payload["ok"] is True
     assigned_building = assign_payload.get("building", {})
     assert assigned_building.get("active_workers") == 1
+    state_snapshot = assign_payload.get("state", {})
+    population_snapshot = state_snapshot.get("population", {})
+    assert population_snapshot.get("available") == 1
 
     for _ in range(5):
         tick_response = client.post("/api/tick", json={"dt": 1})


### PR DESCRIPTION
## Summary
- surface available population counts in the backend snapshot so worker assignments persist correctly
- sync building cards with the assign/unassign API responses and guard the Jobs panel so it no longer sends backend mutations
- keep the Trade column as a UI-only control while keeping the polling state in sync with the server version

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df485e3f70833287dd290fcac3ba35