### PR TITLE
Refine worker assignment endpoint and frontend syncing

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -289,10 +289,17 @@ body {
 
 .worker-group {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
   font-size: 0.75rem;
   color: rgb(203 213 225);
+}
+
+.worker-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .worker-label {
@@ -322,6 +329,20 @@ body {
   background: rgb(15 23 42 / 0.6);
   color: rgb(226 232 240);
   padding: 0.2rem 0.3rem;
+}
+
+.worker-feedback {
+  margin: 0;
+  font-size: 0.7rem;
+  color: rgb(148 163 184);
+}
+
+.worker-feedback[data-variant="error"] {
+  color: rgb(248 113 113);
+}
+
+.worker-feedback[data-variant="success"] {
+  color: rgb(74 222 128);
 }
 
 .bar {

--- a/tests/test_e2e_init.py
+++ b/tests/test_e2e_init.py
@@ -79,12 +79,13 @@ def test_forced_init_and_first_production_cycle(client):
     assert after_idle_state["items"]["wood"] == pytest.approx(0.0)
 
     assign_response = client.post(
-        f"/api/buildings/{building['id']}/assign",
-        json={"workers": 1},
+        f"/api/buildings/{building['id']}/workers",
+        json={"delta": 1},
     )
     assert assign_response.status_code == 200
     assign_payload = assign_response.get_json()
     assert assign_payload["ok"] is True
+    assert assign_payload["delta"] == 1
     assigned_building = assign_payload.get("building", {})
     assert assigned_building.get("active_workers") == 1
     state_snapshot = assign_payload.get("state", {})


### PR DESCRIPTION
## Summary
- unify worker mutation under `/api/buildings/<id>/workers`, validate input, and return updated snapshots
- ensure worker deltas execute via the short-lived `GameState` lock to avoid contention and expose delta metadata
- update the UI to manage per-building syncing/errors, avoid Jobs/Trade mutations, and render immediate server responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df5ec9ac708332aaa8c763614c3409