### PR TITLE
Fix worker assignment sync and add instrumentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,47 @@
 import logging
+import time
+import uuid
+from datetime import datetime, timezone
 
 from flask import Flask, jsonify, render_template, request
 
 from api import ui_bridge
+from core.game_state import get_game_state
 from core.scheduler import ensure_tick_loop
 
 app = Flask(__name__)
 ensure_tick_loop()
 
 logger = logging.getLogger(__name__)
+
+
+def _generate_request_metadata() -> tuple[str, str]:
+    request_id = str(uuid.uuid4())
+    server_time = datetime.now(timezone.utc).isoformat()
+    return request_id, server_time
+
+
+def _enrich_payload(payload: dict, request_id: str, server_time: str) -> dict:
+    body = dict(payload or {})
+    body["request_id"] = request_id
+    body["server_time"] = server_time
+    nested_state = body.get("state")
+    if isinstance(nested_state, dict):
+        nested_copy = dict(nested_state)
+        nested_copy.setdefault("request_id", request_id)
+        nested_copy.setdefault("server_time", server_time)
+        body["state"] = nested_copy
+    return body
+
+
+def _json_response(payload: dict, status: int = 200, *, request_id: str, server_time: str):
+    body = _enrich_payload(payload, request_id, server_time)
+    response = jsonify(body)
+    response.status_code = status
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
 
 
 @app.route("/")
@@ -24,6 +57,8 @@ def public_state():
     payload = ui_bridge.get_basic_state()
     wood_amount = payload.get("items", {}).get("wood")
     logger.info("/state payload wood=%.1f", wood_amount if wood_amount is not None else 0.0)
+    request_id, server_time = _generate_request_metadata()
+    payload = _enrich_payload(payload, request_id, server_time)
     response = jsonify(payload)
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     response.headers["Pragma"] = "no-cache"
@@ -41,7 +76,8 @@ def api_init():
         reset_flag = payload.get("reset") or payload.get("force_reset")
 
     response = ui_bridge.init_game(reset_flag)
-    return jsonify(response)
+    request_id, server_time = _generate_request_metadata()
+    return _json_response(response, request_id=request_id, server_time=server_time)
 
 
 @app.get("/api/state")
@@ -49,7 +85,8 @@ def api_state():
     """Return the current snapshot of the game state."""
 
     response = ui_bridge.get_state()
-    return jsonify(response)
+    request_id, server_time = _generate_request_metadata()
+    return _json_response(response, request_id=request_id, server_time=server_time)
 
 
 @app.post("/api/tick")
@@ -59,7 +96,8 @@ def api_tick():
     payload = request.get_json(silent=True) or {}
     dt = payload.get("dt", 1)
     response = ui_bridge.tick(dt)
-    return jsonify(response)
+    request_id, server_time = _generate_request_metadata()
+    return _json_response(response, request_id=request_id, server_time=server_time)
 
 
 @app.post("/api/buildings/<int:building_id>/workers")
@@ -74,25 +112,50 @@ def api_change_workers(building_id: int):
             if payload.get("workers") is not None
             else payload.get("count")
         )
+    request_id, server_time = _generate_request_metadata()
+    state = get_game_state()
+    before_snapshot = state.worker_allocation_snapshot(building_id)
     logger.info(
-        "Worker request: building=%s delta=%s payload_keys=%s",
+        "Worker handler enter route=/api/buildings/%s/workers request_id=%s delta=%s workers_before=%s population_available=%s timestamp=%s",
         building_id,
+        request_id,
         delta,
-        sorted(payload.keys()),
+        before_snapshot.get("workers"),
+        before_snapshot.get("population_available"),
+        server_time,
     )
+    start = time.perf_counter()
     response = ui_bridge.change_building_workers(building_id, delta)
     status = 200
     if not response.get("ok", False):
         error_code = response.get("error_code")
-        status = 404 if error_code == "building_not_found" else 400
+        if error_code == "building_not_found":
+            status = 404
+        elif error_code == "assignment_failed":
+            status = 409
+        else:
+            status = 400
+    duration_ms = (time.perf_counter() - start) * 1000.0
+    after_snapshot = state.worker_allocation_snapshot(building_id)
     logger.info(
-        "Worker response: building=%s delta=%s ok=%s status=%s",
+        "Worker handler exit route=/api/buildings/%s/workers request_id=%s delta=%s workers_before=%s workers_after=%s population_available_before=%s population_available_after=%s status=%s duration_ms=%.2f timestamp=%s",
         building_id,
+        request_id,
         delta,
-        response.get("ok"),
+        before_snapshot.get("workers"),
+        after_snapshot.get("workers"),
+        before_snapshot.get("population_available"),
+        after_snapshot.get("population_available"),
         status,
+        duration_ms,
+        datetime.now(timezone.utc).isoformat(),
     )
-    return jsonify(response), status
+    return _json_response(
+        response,
+        status,
+        request_id=request_id,
+        server_time=server_time,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add request metadata and detailed logging around worker assignment in the Flask app
- log tick summaries with timestamps and expose worker snapshots from the game state
- update the frontend to honour server timestamps, handle worker assignment logging, and adopt backend building ids

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df6427f878833294ff86b606b8bc7e