### PR TITLE
Normalize building IDs and stabilize worker assignments

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -21,14 +21,11 @@ class Building:
     assigned_workers: int = 0
     cycle_progress: float = 0.0
     status: str = "pausado"
-    id: int = field(init=False)
+    id: str = field(init=False)
     production_report: Dict[str, object] = field(default_factory=dict)
 
-    _next_id: int = 1
-
     def __post_init__(self) -> None:
-        self.id = Building._next_id
-        Building._next_id += 1
+        self.id = config.resolve_building_public_id(self.type_key)
         self._maintenance_notified = False
         self._last_effective_rate = 0.0
         self.production_report = self._new_report()
@@ -410,7 +407,8 @@ class Building:
 
     @classmethod
     def reset_ids(cls, next_id: int = 1) -> None:
-        cls._next_id = next_id
+        # Compatibility shim: identifiers are stable strings now.
+        _ = next_id  # pragma: no cover
 
 
 def build_from_config(type_key: str) -> Building:

--- a/core/config.py
+++ b/core/config.py
@@ -6,12 +6,53 @@ from typing import Dict, Mapping, Optional, Tuple
 
 from .resources import ALL_RESOURCES, Resource, normalise_mapping
 
-# Building identifiers used across the backend.
+# ---------------------------------------------------------------------------
+# Building identifiers and normalisation helpers
+
 WOODCUTTER_CAMP = "woodcutter_camp"
 LUMBER_HUT = "lumber_hut"
 MINER = "miner"
 FARMER = "farmer"
 ARTISAN = "artisan"
+
+BUILDING_PUBLIC_IDS: Dict[str, str] = {
+    WOODCUTTER_CAMP: "woodcutter_camp",
+    LUMBER_HUT: "lumber_hut",
+    MINER: "miner",
+    FARMER: "farmer",
+    ARTISAN: "artisan",
+}
+
+_BUILDING_ID_LOOKUP: Dict[str, str] = {
+    public_id: type_key for type_key, public_id in BUILDING_PUBLIC_IDS.items()
+}
+
+
+def normalise_building_key(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("El identificador de edificio debe ser una cadena")
+    key = value.strip().lower().replace("-", "_")
+    if not key:
+        raise ValueError("El identificador de edificio está vacío")
+    return key
+
+
+def resolve_building_type(value: str) -> str:
+    key = normalise_building_key(value)
+    if key in BUILDING_PUBLIC_IDS:
+        return key
+    mapped = _BUILDING_ID_LOOKUP.get(key)
+    if mapped:
+        return mapped
+    raise ValueError(f"Identificador de edificio desconocido: {value}")
+
+
+def resolve_building_public_id(value: str) -> str:
+    type_key = resolve_building_type(value)
+    return BUILDING_PUBLIC_IDS[type_key]
+
+# ---------------------------------------------------------------------------
+# Building metadata
 
 BUILDING_NAMES: Dict[str, str] = {
     WOODCUTTER_CAMP: "Woodcutter Camp",
@@ -144,7 +185,12 @@ WORKERS_INICIALES: int = POPULATION_INITIAL
 STARTING_RESOURCES: Dict[Resource, float] = {resource: 0.0 for resource in ALL_RESOURCES}
 
 STARTING_BUILDINGS: Tuple[Mapping[str, object], ...] = (
-    {"type": WOODCUTTER_CAMP, "workers": 0, "enabled": True},
+    {
+        "type": WOODCUTTER_CAMP,
+        "workers": 1,
+        "built": True,
+        "enabled": True,
+    },
 )
 
 SEASON_MODIFIERS: Dict[str, Dict[str, float]] = {


### PR DESCRIPTION
## Summary
- normalize building identifiers to snake_case everywhere and centralize resolution helpers
- update worker assignment handling to use the new IDs, return metadata, and add detailed logging on success/error paths
- refresh the frontend to use the normalized IDs, guard against stale polling, and ensure wood production/worker UI stay in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df69f5dbf08332a6a3c7e396db23ae