### PR TITLE
feat: show wood production per minute and enforce woodcutter build cost

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Dict
 
 from core import config
-from core.game_state import get_game_state
+from core.game_state import InsufficientResourcesError, get_game_state
 from core.jobs import WorkerAllocationError
 from core.persistence import load_game as core_load_game, save_game as core_save_game
 from core.resources import Resource
@@ -115,17 +115,52 @@ def get_inventory_snapshot() -> Dict[str, object]:
 def build_building(type_key: str) -> Dict[str, object]:
     state = get_game_state()
     try:
-        building = state.build_building(type_key)
-        snapshot = state.snapshot_building(building.id)
-        return _success_response(
-            building=snapshot,
-            production_report=snapshot["last_report"],
-        )
+        canonical_type = config.resolve_building_type(type_key)
     except ValueError as exc:
-        message = str(exc)
-        if "Tipo de edificio desconocido" in message:
-            return _error_response("invalid_building_type", message)
-        return _error_response("missing_resources", message)
+        error = _error_response(
+            "invalid_building_type",
+            str(exc),
+            http_status=404,
+        )
+        error.update(state.response_metadata())
+        return error
+
+    try:
+        building = state.build_building(canonical_type)
+    except InsufficientResourcesError as exc:
+        requirements = {
+            resource.value.lower(): float(amount)
+            for resource, amount in exc.requirements.items()
+        }
+        error: Dict[str, object] = {
+            "ok": False,
+            "error": "INSUFFICIENT_RESOURCES",
+            "error_code": "insufficient_resources",
+            "error_message": "Recursos insuficientes",
+            "requires": requirements,
+            "http_status": 400,
+        }
+        error.update(state.response_metadata())
+        return error
+    except ValueError as exc:
+        error = _error_response("build_failed", str(exc), http_status=400)
+        error.update(state.response_metadata())
+        return error
+
+    snapshot = state.snapshot_building(building.id)
+    state_payload = state.basic_state_snapshot()
+    metadata = state.response_metadata(state_payload.get("version"))
+    payload: Dict[str, object] = {
+        "building": snapshot,
+        "buildings": [snapshot],
+        "production_report": snapshot["last_report"],
+        "state": state_payload,
+        "inventory": state.inventory_snapshot(),
+        "resources": state.resources_snapshot(),
+        "http_status": 200,
+    }
+    payload.update(metadata)
+    return _success_response(**payload)
 
 
 def demolish_building(building_id: int) -> Dict[str, object]:

--- a/app.py
+++ b/app.py
@@ -63,6 +63,19 @@ def api_tick():
     return jsonify(response)
 
 
+@app.post("/api/buildings/<string:building_id>/build")
+def api_build_building(building_id: str):
+    """Construct a new instance of the requested building."""
+
+    response = ui_bridge.build_building(building_id)
+    status = 200
+    if not response.get("ok", False):
+        status = int(response.get("http_status", 400))
+    else:
+        status = int(response.get("http_status", status))
+    return jsonify(response), status
+
+
 @app.post("/api/buildings/<string:building_id>/workers")
 def api_change_workers(building_id: str):
     """Apply a worker delta to the target building."""

--- a/core/config.py
+++ b/core/config.py
@@ -62,13 +62,16 @@ BUILDING_NAMES: Dict[str, str] = {
     ARTISAN: "Artisan Workshop",
 }
 
-COSTOS_CONSTRUCCION: Dict[str, Dict[Resource, float]] = {
-    WOODCUTTER_CAMP: {Resource.WOOD: 12, Resource.STONE: 4},
-    LUMBER_HUT: {Resource.WOOD: 25, Resource.STONE: 12},
-    MINER: {Resource.WOOD: 18, Resource.STONE: 14},
-    FARMER: {Resource.WOOD: 20, Resource.STONE: 15, Resource.SEEDS: 5},
-    ARTISAN: {Resource.WOOD: 15, Resource.STONE: 20, Resource.PLANK: 4},
+BUILD_COSTS: Dict[str, Dict[Resource, float]] = {
+    WOODCUTTER_CAMP: {Resource.WOOD: 1},
+    LUMBER_HUT: {},
+    MINER: {},
+    FARMER: {},
+    ARTISAN: {},
 }
+
+# Backwards compatibility alias for legacy references.
+COSTOS_CONSTRUCCION: Dict[str, Dict[Resource, float]] = BUILD_COSTS
 
 @dataclass(frozen=True)
 class BuildingRecipe:

--- a/static/styles.css
+++ b/static/styles.css
@@ -611,6 +611,15 @@ button:focus-visible {
   list-style: none;
 }
 
+.io-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: rgb(226 232 240 / 0.85);
+  text-transform: none;
+}
+
 .io-item {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add backend build cost validation and include per-minute production data in building snapshots
- update frontend to display Wood/min output, disable build when resources are lacking, and call the build API
- document the new behaviour with backend tests covering cost enforcement and production reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df7788cbd883328d2434a1056d3121