### PR TITLE
Enable multiple woodcutter builds and functional demolish handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,6 +76,19 @@ def api_build_building(building_id: str):
     return jsonify(response), status
 
 
+@app.post("/api/buildings/<string:building_id>/demolish")
+def api_demolish_building(building_id: str):
+    """Demolish an existing instance of the requested building."""
+
+    response = ui_bridge.demolish_building(building_id)
+    status = 200
+    if not response.get("ok", False):
+        status = int(response.get("http_status", 400))
+    else:
+        status = int(response.get("http_status", status))
+    return jsonify(response), status
+
+
 @app.post("/api/buildings/<string:building_id>/workers")
 def api_change_workers(building_id: str):
     """Apply a worker delta to the target building."""

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -80,6 +80,18 @@ def load_game(path: str) -> None:
             except ValueError:
                 building.id = config.resolve_building_public_id(building.type_key)
         building.enabled = bool(entry.get("enabled", True))
+        raw_built = entry.get("built")
+        if raw_built is None:
+            built_count = 1 if building.enabled else 0
+        else:
+            try:
+                built_count = int(float(raw_built))
+            except (TypeError, ValueError):
+                built_count = 0
+            built_count = max(0, built_count)
+        building.built = built_count
+        if built_count <= 0:
+            building.enabled = False
         building.cycle_progress = float(entry.get("cycle_progress", 0.0))
         assigned = int(entry.get("assigned_workers", 0))
         building.assigned_workers = max(0, min(assigned, building.max_workers))


### PR DESCRIPTION
## Summary
- allow multiple Woodcutter Camp builds with a 1 wood cost per construction, update demolish to adjust built counts, workers, and snapshots, and surface richer payloads via the API
- persist numeric build counts, update backend tests, and add a demolish endpoint response that mirrors the build payload
- remove Building card “Assign” buttons, wire build/demolish UI actions to the new backend behavior, and refresh disabled states and feedback messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df80646f488332a79361f052fc73ec