### PR TITLE
Implement seasonal population growth and gold income

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -70,7 +70,18 @@ def tick(dt: float) -> Dict[str, object]:
     """Advance the simulation by ``dt`` seconds."""
 
     state = get_game_state()
-    state.tick(max(0.0, float(dt)))
+    state.advance_time(max(0.0, float(dt)))
+    return _success_response(**_state_payload(state))
+
+
+def season_start(season: str, at: float) -> Dict[str, object]:
+    """Trigger the season start event at the provided timestamp."""
+
+    state = get_game_state()
+    normalized = str(season or "").strip().lower()
+    if normalized.title() in state.season_clock.seasons:
+        state.season_clock.load(normalized.title())
+    state.on_season_start(normalized, float(at))
     return _success_response(**_state_payload(state))
 
 

--- a/app.py
+++ b/app.py
@@ -63,6 +63,54 @@ def api_tick():
     return jsonify(response)
 
 
+@app.post("/season/start")
+def api_season_start():
+    """Trigger a season start event at a specific timestamp."""
+
+    payload = request.get_json(silent=True) or {}
+    season = payload.get("season")
+    at = payload.get("at")
+    if season is None or at is None:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "invalid_payload",
+                    "error_message": "Missing 'season' or 'at' in payload",
+                }
+            ),
+            400,
+        )
+    try:
+        at_value = float(at)
+    except (TypeError, ValueError):
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "invalid_timestamp",
+                    "error_message": "Timestamp 'at' must be a number",
+                }
+            ),
+            400,
+        )
+
+    try:
+        response = ui_bridge.season_start(season, at_value)
+    except ValueError as exc:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "invalid_season",
+                    "error_message": str(exc),
+                }
+            ),
+            400,
+        )
+    return jsonify(response)
+
+
 @app.post("/api/buildings/<string:building_id>/build")
 def api_build_building(building_id: str):
     """Construct a new instance of the requested building."""

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -16,7 +16,7 @@ async def _run_tick_loop(interval: float) -> None:
     state = get_game_state()
     while True:
         try:
-            state.tick(interval)
+            state.advance_time(interval)
         except Exception:
             # Avoid breaking the loop on unexpected errors; log via print.
             import traceback

--- a/core/seasons.py
+++ b/core/seasons.py
@@ -1,0 +1,11 @@
+"""Season-related constants and helpers for the game backend."""
+
+from __future__ import annotations
+
+SEASON_GRANTS = {
+    "spring": 2,
+    "summer": 3,
+    "autumn": 2,
+    "winter": 1,
+}
+

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,7 +20,12 @@ def reset_state():
 def test_basic_state_snapshot_defaults():
     state = get_game_state()
     snapshot = state.basic_state_snapshot()
-    assert snapshot["population"] == {"current": 2, "capacity": 20, "available": 1}
+    assert snapshot["population"] == {
+        "current": 2,
+        "capacity": 20,
+        "available": 1,
+        "total": 2,
+    }
     building_payload = snapshot["buildings"][config.WOODCUTTER_CAMP]
     assert building_payload == {
         "built": 1,
@@ -44,7 +49,7 @@ def test_wood_production_matches_formula():
     state = get_game_state()
     state.assign_workers_to_woodcutter(1)
     state.recompute_wood_caps()
-    state.tick(10.0)
+    state.advance_time(10.0)
     snapshot = state.basic_state_snapshot()
     assert snapshot["items"]["wood"] == pytest.approx(1.0, rel=1e-9, abs=1e-9)
     assert snapshot["wood_state"]["wood_production_per_second"] == pytest.approx(0.1)
@@ -74,7 +79,7 @@ def test_capacity_clamp_enforced():
     state.assign_workers_to_woodcutter(2)
     state.inventory.set_amount(Resource.WOOD, 49)
     state.recompute_wood_caps()
-    state.tick(10.0)
+    state.advance_time(10.0)
     assert state.wood_max_capacity == pytest.approx(50.0)
     assert state.wood == pytest.approx(50.0)
 
@@ -85,7 +90,7 @@ def test_no_camps_means_no_production():
     assert building is not None
     state.demolish_building(building.id)
     state.assign_workers_to_woodcutter(5)
-    state.tick(60.0)
+    state.advance_time(60.0)
     state_snapshot = state.basic_state_snapshot()
     wood_state = state_snapshot["wood_state"]
     assert wood_state["woodcutter_camps_built"] == 0

--- a/tests/test_population_gold.py
+++ b/tests/test_population_gold.py
@@ -1,0 +1,95 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from api import ui_bridge
+from core.game_state import get_game_state
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    ui_bridge.init_game(force_reset=True)
+    yield
+
+
+def _set_population(state, total):
+    current = state.population_total()
+    if total <= current:
+        return
+    state._grant_new_villagers(total - current)
+
+
+def test_summer_adds_three_up_to_cap():
+    state = get_game_state()
+    _set_population(state, 17)
+    previous_total = state.population_total()
+    assert previous_total == 17
+
+    state.on_season_start("summer", state.time["last_tick"] + 10.0)
+    assert state.population_total() == 20
+    assert state.population["total"] == 20
+    assert len(state.population["villagers"]) == 20
+    assert state.population["villagers"][-1]["employed"] is False
+
+
+def test_autumn_adds_two():
+    state = get_game_state()
+    initial_total = state.population_total()
+    state.on_season_start("autumn", state.time["last_tick"] + 5.0)
+    assert state.population_total() == initial_total + 2
+
+    ui_bridge.init_game(force_reset=True)
+    state = get_game_state()
+    _set_population(state, 19)
+    state.on_season_start("autumn", state.time["last_tick"] + 15.0)
+    assert state.population_total() == state.population["cap"]
+
+
+def test_winter_adds_one():
+    state = get_game_state()
+    initial_total = state.population_total()
+    state.on_season_start("winter", state.time["last_tick"] + 3.0)
+    assert state.population_total() == min(
+        state.population["cap"], initial_total + 1
+    )
+
+
+def test_gold_growth_idle_and_employed():
+    state = get_game_state()
+    _set_population(state, 5)
+    villagers = state.population["villagers"]
+    villagers[0]["employed"] = True
+    villagers[1]["employed"] = True
+    state.resources["gold"] = 0.0
+
+    state.tick(state.time["last_tick"] + 10.0)
+    assert state.resources["gold"] == pytest.approx(0.5)
+
+
+def test_tick_is_idempotent_on_zero_dt():
+    state = get_game_state()
+    _set_population(state, 4)
+    state.resources["gold"] = 1.0
+    state.tick(state.time["last_tick"])
+    assert state.resources["gold"] == pytest.approx(1.0)
+
+
+def test_on_season_start_idempotent_same_timestamp():
+    state = get_game_state()
+    stamp = state.time["last_tick"] + 2.0
+    state.on_season_start("spring", stamp)
+    total_after_first = state.population_total()
+    state.on_season_start("spring", stamp)
+    assert state.population_total() == total_after_first
+
+
+def test_inactivity_catchup():
+    state = get_game_state()
+    _set_population(state, 10)
+    state.resources["gold"] = 0.0
+    state.tick(state.time["last_tick"] + 120.0)
+    assert state.resources["gold"] == pytest.approx(12.0)
+


### PR DESCRIPTION
## Summary
- track server time, seasonal grants, villagers, and passive gold inside the game state
- expose season-start logic through the API and keep the scheduler using absolute time
- add regression tests that cover population limits, passive gold income, and idempotent ticks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df90640290833283656ca070e54c95