### PR TITLE
Add feature-flagged stacked building view

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1637,3 +1637,30 @@ button:focus-visible {
 .verify-overlay__row--fail .verify-overlay__label {
   color: rgb(248 113 113);
 }
+
+.stacked-header{display:flex;align-items:center;gap:0.75rem;margin-left:auto;flex-wrap:wrap;}
+.stacked-header__flag{display:flex;align-items:center;gap:0.4rem;font-size:0.85rem;color:rgb(203 213 225);}
+.stacked-header__flag input{accent-color:rgb(59 130 246);}
+.stacked-header__modes{display:inline-flex;border:1px solid rgb(71 85 105);border-radius:0.5rem;overflow:hidden;}
+.stacked-header__modes button{background:rgb(15 23 42 / 0.75);color:rgb(148 163 184);padding:0.35rem 0.75rem;font-size:0.8rem;font-weight:600;}
+.stacked-header__modes button.is-active{background:rgb(59 130 246 / 0.25);color:rgb(226 232 240);}
+.stacked-controls{display:flex;flex-wrap:wrap;gap:0.75rem;margin:1rem 0;color:rgb(203 213 225);font-size:0.85rem;}
+.stacked-controls label{display:flex;align-items:center;gap:0.4rem;}
+.stacked-controls input[type="number"]{width:4rem;padding:0.25rem;border-radius:0.4rem;border:1px solid rgb(71 85 105);background:rgb(15 23 42 / 0.8);color:rgb(226 232 240);}
+.stacked-grid{display:grid;gap:1rem;margin-bottom:1.5rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}
+.stacked-grid[hidden]{display:none;}
+.stacked-card{display:flex;flex-direction:column;gap:0.75rem;padding:1rem;border-radius:0.85rem;background:rgb(30 41 59 / 0.85);border:1px solid rgb(51 65 85);box-shadow:0 10px 28px rgb(15 23 42 / 0.35);}
+.stacked-card__header{display:flex;justify-content:space-between;align-items:center;gap:0.75rem;}
+.stacked-card__title{display:flex;align-items:center;gap:0.5rem;font-weight:600;color:rgb(226 232 240);}
+.stacked-card__icon{font-size:1.5rem;line-height:1;}
+.stacked-card__status{display:inline-flex;align-items:center;gap:0.35rem;font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;color:rgb(148 163 184);}
+.stacked-card__status-indicator{width:0.6rem;height:0.6rem;border-radius:999px;background:rgb(148 163 184);}
+.stacked-card__status--good .stacked-card__status-indicator{background:rgb(34 197 94);}
+.stacked-card__status--warn .stacked-card__status-indicator{background:rgb(234 179 8);}
+.stacked-card__status--bad .stacked-card__status-indicator{background:rgb(239 68 68);}
+.stacked-card__meta,.stacked-card__production{display:flex;justify-content:space-between;gap:0.5rem;font-size:0.85rem;color:rgb(203 213 225);}
+.stacked-card__levels{display:flex;flex-wrap:wrap;gap:0.35rem;font-size:0.75rem;color:rgb(226 232 240);}
+.stacked-card__levels span{background:rgb(30 64 175 / 0.28);padding:0.15rem 0.5rem;border-radius:999px;}
+.stacked-card__actions{display:grid;gap:0.5rem;grid-template-columns:repeat(2,minmax(0,1fr));}
+.stacked-card__button{padding:0.45rem 0.5rem;border-radius:0.5rem;border:1px solid rgb(59 130 246 / 0.4);background:rgb(59 130 246 / 0.15);color:rgb(191 219 254);font-size:0.85rem;font-weight:600;transition:background 0.15s ease;}
+.stacked-card__button:hover{background:rgb(59 130 246 / 0.3);}

--- a/templates/index.html
+++ b/templates/index.html
@@ -208,6 +208,13 @@
             <button type="button" class="density-toggle__button is-active" data-density="compact">Compact</button>
             <button type="button" class="density-toggle__button" data-density="detailed">Detailed</button>
           </div>
+          <div id="stacked-header-controls" class="stacked-header" hidden>
+            <label class="stacked-header__flag"><input type="checkbox" id="stacked-flag-checkbox" />Vista apilada</label>
+            <div id="stacked-view-toggle" class="stacked-header__modes" hidden role="group" aria-label="Alternar vista">
+              <button type="button" data-stacked-view="classic" class="is-active" aria-pressed="true">Vista clásica</button>
+              <button type="button" data-stacked-view="stacked" aria-pressed="false">Vista apilada</button>
+            </div>
+          </div>
         </div>
         <div class="building-toolbar" id="building-filters">
           <div class="building-toolbar__filters">
@@ -238,6 +245,12 @@
             </select>
           </div>
         </div>
+        <div id="stacked-controls" class="stacked-controls" hidden>
+          <label><input type="checkbox" id="stacked-filter-active" checked />Solo activos</label>
+          <label>Nivel mínimo <input type="number" id="stacked-filter-level" min="0" max="10" value="0" /></label>
+          <label><input type="checkbox" id="stacked-filter-inputs" />Inputs OK</label>
+        </div>
+        <div id="buildings-stacked" class="stacked-grid" hidden role="list"></div>
         <div class="building-grid" id="buildings-grid" role="list"></div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- add the `UI_STACKED_VIEW` feature flag wiring and helpers so the stacked cards can be toggled without touching backend APIs
- render aggregated stacked building cards with filters and controls when the flag is on, keeping the classic list as the default
- style the stacked controls/cards with scoped `.stacked-*` rules and extend the template markup with the new toggle and filter containers

## Testing
- pytest

## Lines / Files
- static/main.js: +106/-1
- static/styles.css: +27/-0
- templates/index.html: +13/-0

## Feature flag
- `UI_STACKED_VIEW` (off by default). Enable via `?stacked=1` or by checking the "Vista apilada" checkbox; disable by removing the query param or unchecking the box.

------
https://chatgpt.com/codex/tasks/task_e_68e0a14a0bbc8332873948b0ec415074