### PR TITLE
Make stacked building view visible by default

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1293,7 +1293,7 @@
         sort: "efficiency",
         viewMode: "classic",
         stackedFilters: {
-          onlyActive: true,
+          onlyActive: false,
           minLevel: 0,
           requireInputsOk: false,
         },

--- a/templates/index.html
+++ b/templates/index.html
@@ -246,7 +246,7 @@
           </div>
         </div>
         <div id="stacked-controls" class="stacked-controls" hidden>
-          <label><input type="checkbox" id="stacked-filter-active" checked />Solo activos</label>
+          <label><input type="checkbox" id="stacked-filter-active" />Solo activos</label>
           <label>Nivel mínimo <input type="number" id="stacked-filter-level" min="0" max="10" value="0" /></label>
           <label><input type="checkbox" id="stacked-filter-inputs" />Inputs OK</label>
         </div>


### PR DESCRIPTION
## Summary
- default the stacked view state to keep the "solo activos" filter off so cards render even before assigning workers
- align the stacked filter checkbox markup with the new default state

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall .`
- `pytest`
- `flask run --host=0.0.0.0 --port=5000`

------
https://chatgpt.com/codex/tasks/task_e_68e3d0bb4ae483328370b718b4225dc5