### PR TITLE
Overhaul village design UI and supply chain logic

### DIFF
--- a/api/ui_bridge.py
+++ b/api/ui_bridge.py
@@ -385,6 +385,20 @@ def demolish_village_tile(x: int, y: int) -> Dict[str, object]:
     return _success_response(**payload)
 
 
+def upgrade_village_tile(x: int, y: int) -> Dict[str, object]:
+    state = get_game_state()
+    try:
+        snapshot = state.upgrade_village_structure(x, y)
+    except VillagePlacementError as exc:
+        error = _error_response("invalid_upgrade", str(exc), http_status=400)
+        error.update(state.response_metadata())
+        return error
+    metadata = state.response_metadata(snapshot.get("version"))
+    payload = {"village": snapshot}
+    payload.update(metadata)
+    return _success_response(**payload)
+
+
 def save_village_design(path: str | None = None) -> Dict[str, object]:
     state = get_game_state()
     try:

--- a/app.py
+++ b/app.py
@@ -216,6 +216,16 @@ def api_village_demolish():
     return jsonify(response), status
 
 
+@app.post("/api/village/upgrade")
+def api_village_upgrade():
+    payload = request.get_json(silent=True) or {}
+    x = payload.get("x")
+    y = payload.get("y")
+    response = ui_bridge.upgrade_village_tile(x, y)
+    status = 200 if response.get("ok", False) else int(response.get("http_status", 400))
+    return jsonify(response), status
+
+
 @app.post("/api/village/save")
 def api_village_save():
     payload = request.get_json(silent=True) or {}

--- a/core/game_state.py
+++ b/core/game_state.py
@@ -59,6 +59,7 @@ class GameState:
         self.max_workers_woodcutter: int = 0
         self.wood_max_capacity: float = 0.0
         self.wood_production_per_second: float = 0.0
+        self.village_sandbox: bool = True
         self._initialise_state()
 
     # ------------------------------------------------------------------
@@ -106,6 +107,7 @@ class GameState:
             Building.reset_ids()
             self.trade_manager = TradeManager(config.TRADE_DEFAULTS)
             self.village_design = VillageDesignState()
+            self.village_sandbox = True
             self._initialise_inventory()
             self.resources["gold"] = self.inventory.get_amount(Resource.GOLD)
             self.last_production_reports = {}
@@ -1044,17 +1046,17 @@ class GameState:
 
         reservation = None
         with self._lock:
-            if requirements:
+            if not self.village_sandbox and requirements:
                 reservation = self.inventory.reserve(requirements)
                 if reservation is None:
                     raise InsufficientResourcesError(requirements)
             try:
                 _, effects = self.village_design.place_building(ix, iy, building_key)
             except Exception as exc:
-                if reservation is not None:
+                if reservation is not None and not self.village_sandbox:
                     self.inventory.rollback(reservation)
                 raise
-            if reservation is not None:
+            if reservation is not None and not self.village_sandbox:
                 self.inventory.commit(reservation)
             self._apply_village_effects(effects)
             self._state_version += 1
@@ -1089,6 +1091,19 @@ class GameState:
                 for resource, amount in refund.items()
             }
         return snapshot
+
+    def upgrade_village_structure(self, x: int, y: int) -> Dict[str, object]:
+        try:
+            ix = int(x)
+            iy = int(y)
+        except (TypeError, ValueError):
+            raise VillagePlacementError("Invalid coordinates")
+
+        with self._lock:
+            _, effects = self.village_design.upgrade_building(ix, iy)
+            self._apply_village_effects(effects)
+            self._state_version += 1
+        return self.snapshot_village_design()
 
     def save_village_design(self, path: Optional[str] = None) -> str:
         target = Path(path) if path else VILLAGE_DEFAULT_SAVE

--- a/core/village_design.py
+++ b/core/village_design.py
@@ -4,10 +4,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional, Tuple
 
+from collections import defaultdict
+
 from .resources import Resource, normalise_mapping
 
 
-VILLAGE_SIZE = 5
+VILLAGE_SIZE = 10
 DEFAULT_SAVE_PATH = Path(__file__).resolve().parent.parent / "data" / "village_design.json"
 
 
@@ -48,11 +50,16 @@ TERRAIN_TYPES: Dict[str, TerrainDefinition] = {
 
 
 DEFAULT_TERRAIN_LAYOUT: Tuple[Tuple[str, ...], ...] = (
-    ("water", "water", "water", "plain", "plain"),
-    ("water", "plain", "forest", "forest", "plain"),
-    ("plain", "plain", "plain", "forest", "plain"),
-    ("plain", "hill", "plain", "plain", "plain"),
-    ("plain", "plain", "plain", "plain", "plain"),
+    ("water", "water", "water", "plain", "plain", "plain", "forest", "forest", "plain", "plain"),
+    ("water", "water", "plain", "plain", "plain", "forest", "forest", "forest", "plain", "plain"),
+    ("water", "plain", "plain", "forest", "forest", "forest", "plain", "plain", "plain", "plain"),
+    ("plain", "plain", "plain", "forest", "hill", "plain", "plain", "plain", "plain", "plain"),
+    ("plain", "plain", "plain", "hill", "hill", "plain", "plain", "forest", "plain", "plain"),
+    ("plain", "plain", "plain", "plain", "plain", "plain", "plain", "forest", "forest", "plain"),
+    ("plain", "plain", "forest", "forest", "plain", "plain", "plain", "plain", "plain", "plain"),
+    ("plain", "forest", "forest", "plain", "plain", "plain", "plain", "plain", "water", "water"),
+    ("plain", "plain", "plain", "plain", "plain", "plain", "plain", "water", "water", "water"),
+    ("plain", "plain", "plain", "plain", "plain", "plain", "plain", "water", "water", "water"),
 )
 
 
@@ -69,8 +76,11 @@ class VillageBuildingDefinition:
     efficiency_notes: List[str] = field(default_factory=list)
     housing: int = 0
     transport_bonus: float = 0.0
-    storage_radius: int = 0
+    logistics_radius: int = 0
     base_efficiency: float = 1.0
+    inputs: Dict[str, float] = field(default_factory=dict)
+    tier: int = 0
+    workers: int = 0
 
     def to_payload(self) -> Dict[str, object]:
         return {
@@ -84,8 +94,11 @@ class VillageBuildingDefinition:
             "efficiency_notes": list(self.efficiency_notes),
             "housing": self.housing,
             "transport_bonus": self.transport_bonus,
-            "storage_radius": self.storage_radius,
+            "logistics_radius": self.logistics_radius,
             "base_efficiency": self.base_efficiency,
+            "inputs": self.inputs,
+            "tier": self.tier,
+            "workers": self.workers,
             "cost": {
                 resource.value.lower(): float(amount)
                 for resource, amount in self.cost.items()
@@ -94,90 +107,150 @@ class VillageBuildingDefinition:
 
 
 BUILDING_DEFINITIONS: Dict[str, VillageBuildingDefinition] = {
-    "farm": VillageBuildingDefinition(
-        id="farm",
-        name="Crop Farm",
-        category="production",
-        icon="🌾",
-        color="#6fc47f",
-        cost=normalise_mapping({Resource.WOOD: 12, Resource.STONE: 4}),
-        description="Produces food for the village. Gains bonus yield when irrigated by water tiles.",
-        production={"food": 6.0},
-        efficiency_notes=["+20% when adjacent to water"],
-    ),
-    "woodcutter": VillageBuildingDefinition(
-        id="woodcutter",
+    "woodcutter_camp": VillageBuildingDefinition(
+        id="woodcutter_camp",
         name="Woodcutter Camp",
         category="production",
         icon="🪓",
-        color="#8b5a2b",
-        cost=normalise_mapping({Resource.WOOD: 6, Resource.STONE: 2}),
-        description="Chops nearby trees into usable wood.",
-        production={"wood": 8.0},
-        efficiency_notes=["+25% when next to a forest"],
+        color="#b47339",
+        cost=normalise_mapping({}),
+        description="Harvests nearby forests for raw wood. Works best bordering dense woods.",
+        production={"wood": 6.0},
+        efficiency_notes=["+25% when next to a forest tile"],
+        tier=0,
+        workers=2,
     ),
-    "quarry": VillageBuildingDefinition(
-        id="quarry",
+    "stick_gatherer": VillageBuildingDefinition(
+        id="stick_gatherer",
+        name="Stick Gatherer",
+        category="production",
+        icon="🥢",
+        color="#96764a",
+        cost=normalise_mapping({}),
+        description="Collects fallen branches used as basic fuel and crafting material.",
+        production={"sticks": 4.0},
+        efficiency_notes=["Base resource node – no inputs required"],
+        tier=0,
+        workers=1,
+    ),
+    "stone_quarry": VillageBuildingDefinition(
+        id="stone_quarry",
         name="Stone Quarry",
         category="production",
         icon="⛏️",
-        color="#7d7f86",
-        cost=normalise_mapping({Resource.WOOD: 4, Resource.STONE: 10}),
-        description="Extracts stone from nearby hills.",
-        production={"stone": 5.0},
-        efficiency_notes=["+15% when bordering a hill"],
+        color="#80889a",
+        cost=normalise_mapping({}),
+        description="Extracts stone. Gains speed when built on or beside hills.",
+        production={"stone": 4.5},
+        efficiency_notes=["+15% if touching a hill tile"],
+        tier=0,
+        workers=3,
+    ),
+    "gold_panner": VillageBuildingDefinition(
+        id="gold_panner",
+        name="Gold Panner",
+        category="production",
+        icon="🥇",
+        color="#d9b44a",
+        cost=normalise_mapping({}),
+        description="Pans nearby rivers for flecks of gold. Prefers water tiles.",
+        production={"gold": 1.5},
+        efficiency_notes=["+15% when adjacent to water"],
+        tier=0,
+        workers=2,
+    ),
+    "sawmill": VillageBuildingDefinition(
+        id="sawmill",
+        name="Sawmill",
+        category="production",
+        icon="🪚",
+        color="#9b7653",
+        cost=normalise_mapping({}),
+        description="Processes logs into sturdy planks. Needs steady wood supply.",
+        production={"planks": 3.0},
+        inputs={"wood": 4.0},
+        tier=1,
+        workers=3,
+    ),
+    "carpenter": VillageBuildingDefinition(
+        id="carpenter",
+        name="Carpenter Workshop",
+        category="production",
+        icon="🛠️",
+        color="#c2743d",
+        cost=normalise_mapping({}),
+        description="Crafts tools from refined planks to unlock advanced structures.",
+        production={"tools": 2.0},
+        inputs={"planks": 2.0},
+        tier=2,
+        workers=2,
+    ),
+    "warehouse": VillageBuildingDefinition(
+        id="warehouse",
+        name="Village Warehouse",
+        category="storage",
+        icon="📦",
+        color="#d9a441",
+        cost=normalise_mapping({}),
+        description="Central storage that speeds up deliveries within its reach.",
+        production={},
+        transport_bonus=0.3,
+        logistics_radius=2,
+        efficiency_notes=["+30% transport efficiency within 2 tiles"],
+        tier=0,
+        workers=2,
+    ),
+    "cart_station": VillageBuildingDefinition(
+        id="cart_station",
+        name="Cart Station",
+        category="transport",
+        icon="🛒",
+        color="#8f9bb3",
+        cost=normalise_mapping({}),
+        description="Dispatches hand carts to link nearby buildings.",
+        production={},
+        transport_bonus=0.2,
+        logistics_radius=1,
+        efficiency_notes=["+20% transport bonus to adjacent tiles"],
+        tier=0,
+        workers=1,
     ),
     "house": VillageBuildingDefinition(
         id="house",
         name="Village House",
         category="housing",
         icon="🏠",
-        color="#5f8bff",
-        cost=normalise_mapping({Resource.WOOD: 8, Resource.STONE: 4, Resource.GOLD: 10}),
-        description="Increases the population capacity of the settlement.",
-        production={"villagers": 4.0},
-        housing=4,
-        efficiency_notes=["Adds +4 villagers to capacity"],
-    ),
-    "storage": VillageBuildingDefinition(
-        id="storage",
-        name="Warehouse",
-        category="storage",
-        icon="📦",
-        color="#d9a441",
-        cost=normalise_mapping({Resource.WOOD: 10, Resource.STONE: 6}),
-        description="Reduces hauling time for nearby structures.",
-        production={"logistics": 1.0},
-        transport_bonus=0.2,
-        storage_radius=1,
-        efficiency_notes=["Provides +20% transport efficiency within 1 tile"],
-    ),
-    "road": VillageBuildingDefinition(
-        id="road",
-        name="Stone Road",
-        category="transport",
-        icon="🛣️",
-        color="#9d9fa7",
-        cost=normalise_mapping({Resource.STONE: 3}),
-        description="Links buildings together to speed up deliveries.",
-        production={"logistics": 1.0},
-        transport_bonus=0.1,
-        efficiency_notes=["+10% transport bonus for adjacent buildings"],
+        color="#6a91ff",
+        cost=normalise_mapping({}),
+        description="Provides shelter for villagers, increasing population capacity.",
+        production={"villagers": 6.0},
+        housing=6,
+        efficiency_notes=["Receives +10% from nearby wells"],
+        tier=0,
+        workers=0,
     ),
     "well": VillageBuildingDefinition(
         id="well",
         name="Village Well",
-        category="production",
+        category="support",
         icon="⛲",
         color="#58a4d7",
-        cost=normalise_mapping({Resource.STONE: 6, Resource.WOOD: 4}),
-        description="Provides fresh water improving nearby housing.",
-        production={"support": 1.0},
-        efficiency_notes=["Houses adjacent to a well gain +10% efficiency"],
+        cost=normalise_mapping({}),
+        description="Supplies fresh water that comforts nearby homes.",
+        production={},
+        efficiency_notes=["Houses next door gain +10% efficiency"],
+        tier=0,
+        workers=1,
     ),
 }
 
-CATEGORY_ORDER: Tuple[str, ...] = ("production", "housing", "transport", "storage")
+CATEGORY_ORDER: Tuple[str, ...] = (
+    "production",
+    "housing",
+    "storage",
+    "transport",
+    "support",
+)
 
 
 def _format_production_summary(production: Mapping[str, float]) -> Optional[str]:
@@ -226,6 +299,13 @@ class VillageCell:
     efficiency_bonus: float = 0.0
     transport_bonus: float = 0.0
     notes: List[str] = field(default_factory=list)
+    inputs: Dict[str, Dict[str, object]] = field(default_factory=dict)
+    outputs: Dict[str, float] = field(default_factory=dict)
+    status: str = "idle"
+    supply_ratio: float = 1.0
+    distance_penalty: float = 1.0
+    workers_required: int = 0
+    transport_multiplier: float = 1.0
 
     def reset_effects(self) -> None:
         self.efficiency = 1.0
@@ -233,6 +313,13 @@ class VillageCell:
         self.efficiency_bonus = 0.0
         self.transport_bonus = 0.0
         self.notes = []
+        self.inputs = {}
+        self.outputs = {}
+        self.status = "idle"
+        self.supply_ratio = 1.0
+        self.distance_penalty = 1.0
+        self.workers_required = 0
+        self.transport_multiplier = 1.0
 
 
 class VillagePlacementError(Exception):
@@ -246,6 +333,11 @@ class VillageDesignState:
         self.size = VILLAGE_SIZE
         self._next_id = 1
         self._grid: List[List[VillageCell]] = []
+        self._resource_flow: Dict[str, object] = {"nodes": [], "links": []}
+        self._supply_overview: Dict[str, object] = {
+            "buildings": [],
+            "totals": {"production": {}, "consumption": {}},
+        }
         self.reset()
 
     # ------------------------------------------------------------------
@@ -255,6 +347,11 @@ class VillageDesignState:
             for y in range(self.size)
         ]
         self._next_id = 1
+        self._resource_flow = {"nodes": [], "links": []}
+        self._supply_overview = {
+            "buildings": [],
+            "totals": {"production": {}, "consumption": {}},
+        }
         self.recompute_effects()
 
     # ------------------------------------------------------------------
@@ -289,6 +386,18 @@ class VillageDesignState:
         effects = self.recompute_effects()
         return building, effects
 
+    def upgrade_building(
+        self, x: int, y: int
+    ) -> Tuple[VillageBuilding, Dict[str, object]]:
+        cell = self._cell(x, y)
+        if cell.building is None:
+            raise VillagePlacementError("There is no building to upgrade")
+        if cell.building.level >= 5:
+            raise VillagePlacementError("Building already at max level")
+        cell.building.level = min(5, cell.building.level + 1)
+        effects = self.recompute_effects()
+        return cell.building, effects
+
     # ------------------------------------------------------------------
     def _neighbors(self, x: int, y: int) -> Iterable[Tuple[int, int]]:
         for dy in (-1, 0, 1):
@@ -304,77 +413,72 @@ class VillageDesignState:
             for cell in row:
                 cell.reset_effects()
 
+        def distance_penalty(distance: int) -> float:
+            if distance <= 1:
+                return 1.0
+            return max(0.35, 1.0 / (1.0 + 0.25 * (distance - 1)))
+
         total_housing = 0
-        storage_tiles: List[Tuple[int, int, float, int]] = []
-        road_tiles: List[Tuple[int, int, float]] = []
+        logistic_emitters: List[Tuple[int, int, float, int]] = []
         wells: List[Tuple[int, int]] = []
+        building_entries: List[Dict[str, object]] = []
 
         for y, row in enumerate(self._grid):
             for x, cell in enumerate(row):
                 if not cell.building:
                     continue
                 definition = BUILDING_DEFINITIONS[cell.building.type_id]
-                cell.efficiency_base = float(definition.base_efficiency or 1.0)
-                cell.efficiency = cell.efficiency_base
-                cell.efficiency_bonus = 0.0
-                cell.notes = []
+                level = max(1, int(cell.building.level))
+                level_bonus = 1.0 + 0.1 * (level - 1)
+                base_efficiency = float(definition.base_efficiency or 1.0) * level_bonus
+                cell.efficiency_base = base_efficiency
+                cell.efficiency = base_efficiency
+                cell.workers_required = definition.workers
                 terrain = cell.terrain
 
                 production_summary = _format_production_summary(definition.production)
                 if production_summary:
                     cell.notes.append(f"Base production: {production_summary}")
+                if definition.inputs:
+                    inputs_summary = ", ".join(
+                        f"{amount:g} {resource.replace('_', ' ')}"
+                        for resource, amount in definition.inputs.items()
+                    )
+                    cell.notes.append(f"Requires: {inputs_summary}")
 
-                if definition.id == "farm":
-                    if any(self._grid[ny][nx].terrain == "water" for nx, ny in self._neighbors(x, y)):
-                        cell.efficiency *= 1.2
-                        cell.notes.append("Irrigation bonus +20%")
-                elif definition.id == "woodcutter":
+                if definition.id == "woodcutter_camp":
                     if any(self._grid[ny][nx].terrain == "forest" for nx, ny in self._neighbors(x, y)):
                         cell.efficiency *= 1.25
                         cell.notes.append("Adjacent forest +25%")
-                elif definition.id == "quarry":
-                    if any(self._grid[ny][nx].terrain == "hill" for nx, ny in self._neighbors(x, y)) or terrain == "hill":
+                elif definition.id == "stone_quarry":
+                    if terrain == "hill" or any(
+                        self._grid[ny][nx].terrain == "hill" for nx, ny in self._neighbors(x, y)
+                    ):
                         cell.efficiency *= 1.15
                         cell.notes.append("Hill proximity +15%")
+                elif definition.id == "gold_panner":
+                    if terrain == "water" or any(
+                        self._grid[ny][nx].terrain == "water" for nx, ny in self._neighbors(x, y)
+                    ):
+                        cell.efficiency *= 1.15
+                        cell.notes.append("River bonus +15%")
                 elif definition.id == "house":
                     total_housing += definition.housing
                     if definition.housing:
-                        cell.notes.append(
-                            f"Housing capacity +{definition.housing} villagers"
-                        )
-                elif definition.id == "storage":
-                    radius = max(1, int(definition.storage_radius or 1))
-                    storage_tiles.append((x, y, definition.transport_bonus, radius))
-                    bonus_pct = int(round(definition.transport_bonus * 100))
-                    cell.notes.append(
-                        f"Logistics hub radius {radius} (+{bonus_pct}% transport)"
-                    )
-                elif definition.id == "road":
-                    road_tiles.append((x, y, definition.transport_bonus))
-                    bonus_pct = int(round(definition.transport_bonus * 100))
-                    cell.notes.append(f"Road connection bonus +{bonus_pct}%")
+                        cell.notes.append(f"Housing capacity +{definition.housing}")
                 elif definition.id == "well":
                     wells.append((x, y))
-                    cell.notes.append("Supports housing with +10% efficiency")
 
+                if definition.transport_bonus:
+                    radius = max(0, int(definition.logistics_radius or 0))
+                    logistic_emitters.append((x, y, definition.transport_bonus, radius))
+                    bonus_pct = int(round(definition.transport_bonus * 100))
+                    if radius:
+                        cell.notes.append(f"Logistics aura radius {radius} (+{bonus_pct}%)")
+                    else:
+                        cell.notes.append(f"Self logistics +{bonus_pct}%")
 
-        # Apply transport bonuses
-        for x, y, bonus, radius in storage_tiles:
-            for ny in range(max(0, y - radius), min(self.size, y + radius + 1)):
-                for nx in range(max(0, x - radius), min(self.size, x + radius + 1)):
-                    cell = self._grid[ny][nx]
-                    if cell.building and BUILDING_DEFINITIONS[cell.building.type_id].id != "storage":
-                        cell.transport_bonus += bonus
-                        bonus_pct = int(round(bonus * 100))
-                        cell.notes.append(f"Storage support +{bonus_pct}%")
-
-        for x, y, bonus in road_tiles:
-            for nx, ny in self._neighbors(x, y):
-                cell = self._grid[ny][nx]
-                if cell.building and BUILDING_DEFINITIONS[cell.building.type_id].id not in {"road"}:
-                    cell.transport_bonus += bonus
-                    bonus_pct = int(round(bonus * 100))
-                    cell.notes.append(f"Road connection +{bonus_pct}%")
+                building_entries.append({"x": x, "y": y, "cell": cell, "definition": definition})
 
         for x, y in wells:
             for nx, ny in self._neighbors(x, y):
@@ -383,25 +487,225 @@ class VillageDesignState:
                     cell.efficiency *= 1.1
                     cell.notes.append("Well nearby +10%")
 
-        for row in self._grid:
-            for cell in row:
-                if not cell.building:
-                    cell.efficiency_bonus = 0.0
-                    continue
-                if cell.efficiency_base:
-                    cell.efficiency_bonus = cell.efficiency / cell.efficiency_base - 1.0
-                else:
-                    cell.efficiency_bonus = 0.0
-                summary = f"Current efficiency {int(round(cell.efficiency * 100))}%"
-                if summary not in cell.notes:
-                    cell.notes.append(summary)
-                if abs(cell.transport_bonus) > 1e-6:
-                    bonus_pct = int(round(cell.transport_bonus * 100))
-                    summary = f"Transport bonus +{bonus_pct}%"
-                    if summary not in cell.notes:
-                        cell.notes.append(summary)
+        for x, y, bonus, radius in logistic_emitters:
+            for ny in range(max(0, y - radius), min(self.size, y + radius + 1)):
+                for nx in range(max(0, x - radius), min(self.size, x + radius + 1)):
+                    cell = self._grid[ny][nx]
+                    if not cell.building:
+                        continue
+                    cell.transport_bonus += bonus
 
-        return {"housing": total_housing}
+        producers_by_resource: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+        flow_nodes: List[Dict[str, object]] = []
+        flow_links: List[Dict[str, object]] = []
+        total_production: Dict[str, float] = defaultdict(float)
+        total_consumption: Dict[str, float] = defaultdict(float)
+        supply_report: List[Dict[str, object]] = []
+
+        building_entries.sort(key=lambda entry: entry["definition"].tier)
+
+        for entry in building_entries:
+            x = entry["x"]
+            y = entry["y"]
+            cell = entry["cell"]
+            definition = entry["definition"]
+
+            base_multiplier = cell.efficiency
+            logistic_multiplier = 1.0 + cell.transport_bonus
+            cell.transport_multiplier = logistic_multiplier
+            if logistic_multiplier > 1.0005:
+                bonus_pct = int(round((logistic_multiplier - 1.0) * 100))
+                cell.notes.append(f"Logistics bonus +{bonus_pct}%")
+
+            distance_factor = 1.0
+            supply_ratio = 1.0
+            inputs_detail: Dict[str, Dict[str, object]] = {}
+            link_records: List[Dict[str, object]] = []
+
+            if definition.inputs:
+                for resource, required in definition.inputs.items():
+                    providers = producers_by_resource.get(resource, [])
+                    if not providers:
+                        supply_ratio = 0.0
+                        inputs_detail[resource] = {
+                            "required": round(float(required), 2),
+                            "available": 0.0,
+                            "ratio": 0.0,
+                            "status": "missing",
+                            "distance": None,
+                            "provider": None,
+                            "penalty": 0.0,
+                            "actual_rate": 0.0,
+                        }
+                        cell.notes.append(
+                            f"No supply for {resource.replace('_', ' ').title()}"
+                        )
+                        link_records.append(
+                            {
+                                "from": None,
+                                "resource": resource,
+                                "distance": None,
+                                "ratio": 0.0,
+                            }
+                        )
+                        continue
+                    total_available = sum(
+                        float(provider.get("rate", 0.0)) for provider in providers
+                    )
+                    best_provider = min(
+                        providers,
+                        key=lambda provider: abs(int(provider["x"]) - x)
+                        + abs(int(provider["y"]) - y),
+                    )
+                    distance = abs(int(best_provider["x"]) - x) + abs(int(best_provider["y"]) - y)
+                    penalty = distance_penalty(distance)
+                    distance_factor *= penalty
+                    ratio = 1.0
+                    if required > 0:
+                        ratio = min(1.0, total_available / float(required)) if total_available else 0.0
+                    supply_ratio = min(supply_ratio, ratio)
+                    status = "ok"
+                    if ratio <= 0:
+                        status = "missing"
+                    elif ratio < 0.999:
+                        status = "limited"
+                        limited_pct = int(round(ratio * 100))
+                        cell.notes.append(
+                            f"Limited {resource.replace('_', ' ').title()} supply ({limited_pct}%)"
+                        )
+                    if penalty < 0.999:
+                        penalty_pct = int(round((1.0 - penalty) * 100))
+                        cell.notes.append(
+                            f"Distance penalty −{penalty_pct}% ({resource.replace('_', ' ').title()})"
+                        )
+                    inputs_detail[resource] = {
+                        "required": round(float(required), 2),
+                        "available": round(float(total_available), 2),
+                        "ratio": round(float(ratio), 3),
+                        "status": status,
+                        "distance": distance,
+                        "provider": best_provider["id"],
+                        "penalty": round(penalty, 3),
+                        "actual_rate": 0.0,
+                    }
+                    link_records.append(
+                        {
+                            "from": best_provider["id"],
+                            "resource": resource,
+                            "distance": distance,
+                            "ratio": round(float(ratio), 3),
+                        }
+                    )
+
+            if definition.inputs:
+                if supply_ratio <= 0:
+                    cell.status = "inactive"
+                elif supply_ratio < 0.999:
+                    cell.status = "bottleneck"
+                else:
+                    cell.status = "operational"
+            else:
+                cell.status = "operational"
+
+            cell.distance_penalty = distance_factor
+            cell.supply_ratio = supply_ratio
+            final_efficiency = base_multiplier * logistic_multiplier * distance_factor * supply_ratio
+            cell.efficiency = final_efficiency
+            for resource, detail in inputs_detail.items():
+                required = float(definition.inputs.get(resource, 0.0))
+                detail["actual_rate"] = round(required * final_efficiency, 2)
+
+            outputs: Dict[str, float] = {}
+            for resource, amount in definition.production.items():
+                produced = float(amount) * final_efficiency
+                outputs[resource] = round(produced, 2)
+                total_production[resource] += produced
+            cell.outputs = outputs
+
+            for resource, amount in definition.inputs.items():
+                consumed = float(amount) * final_efficiency
+                total_consumption[resource] += consumed
+
+            cell.inputs = inputs_detail
+            if cell.efficiency_base:
+                cell.efficiency_bonus = cell.efficiency / cell.efficiency_base - 1.0
+            else:
+                cell.efficiency_bonus = 0.0
+            summary = f"Effective efficiency {int(round(cell.efficiency * 100))}%"
+            if summary not in cell.notes:
+                cell.notes.append(summary)
+
+            building = cell.building
+            flow_nodes.append(
+                {
+                    "id": building.instance_id,
+                    "type": building.type_id,
+                    "name": definition.name,
+                    "icon": definition.icon,
+                    "category": definition.category,
+                    "position": {"x": x, "y": y},
+                    "level": building.level,
+                    "status": cell.status,
+                    "efficiency": round(cell.efficiency, 3),
+                    "inputs": inputs_detail,
+                    "outputs": outputs,
+                }
+            )
+
+            for link in link_records:
+                link_payload = dict(link)
+                link_payload["to"] = building.instance_id
+                required = float(definition.inputs.get(link_payload["resource"], 0.0))
+                link_payload["rate"] = round(required * final_efficiency, 2)
+                flow_links.append(link_payload)
+
+            for resource, value in outputs.items():
+                providers = producers_by_resource.setdefault(resource, [])
+                providers.append(
+                    {
+                        "id": building.instance_id,
+                        "x": x,
+                        "y": y,
+                        "rate": value,
+                    }
+                )
+
+            supply_report.append(
+                {
+                    "id": building.instance_id,
+                    "type": building.type_id,
+                    "name": definition.name,
+                    "category": definition.category,
+                    "level": building.level,
+                    "status": cell.status,
+                    "efficiency": round(cell.efficiency, 3),
+                    "inputs": inputs_detail,
+                    "outputs": outputs,
+                    "workers": definition.workers,
+                }
+            )
+
+        production_totals = {
+            resource: round(amount, 2) for resource, amount in total_production.items()
+        }
+        consumption_totals = {
+            resource: round(amount, 2) for resource, amount in total_consumption.items()
+        }
+
+        self._resource_flow = {"nodes": flow_nodes, "links": flow_links}
+        self._supply_overview = {
+            "buildings": supply_report,
+            "totals": {
+                "production": production_totals,
+                "consumption": consumption_totals,
+            },
+        }
+
+        return {
+            "housing": total_housing,
+            "production": production_totals,
+            "consumption": consumption_totals,
+        }
 
     # ------------------------------------------------------------------
     def snapshot(self) -> Dict[str, object]:
@@ -434,6 +738,9 @@ class VillageDesignState:
                     "efficiency_multiplier": round(cell.efficiency, 3),
                     "transport_bonus": round(cell.transport_bonus, 3),
                     "level": cell.building.level if cell.building else None,
+                    "status": cell.status,
+                    "supply_ratio": round(cell.supply_ratio, 3),
+                    "distance_penalty": round(cell.distance_penalty, 3),
                 }
                 if cell.building:
                     definition = BUILDING_DEFINITIONS[cell.building.type_id]
@@ -451,6 +758,13 @@ class VillageDesignState:
                         "base_production": definition.production,
                         "housing": definition.housing,
                         "efficiency_notes": definition.efficiency_notes,
+                        "inputs": cell.inputs,
+                        "outputs": cell.outputs,
+                        "status": cell.status,
+                        "supply_ratio": round(cell.supply_ratio, 3),
+                        "distance_penalty": round(cell.distance_penalty, 3),
+                        "transport_multiplier": round(cell.transport_multiplier, 3),
+                        "workers_required": definition.workers,
                     }
                 row_payload.append(cell_payload)
             grid_payload.append(row_payload)
@@ -463,6 +777,8 @@ class VillageDesignState:
             "grid": grid_payload,
             "catalog": catalog,
             "effects": effects,
+            "resource_flow": self._resource_flow,
+            "supply_overview": self._supply_overview,
         }
 
     # ------------------------------------------------------------------

--- a/static/styles.css
+++ b/static/styles.css
@@ -21,6 +21,12 @@ body {
   font-family: inherit;
   margin: 0;
   overflow-x: hidden;
+  color: rgb(226 232 240);
+  background: linear-gradient(165deg, #19261a 0%, #1f2d20 45%, #24342a 100%);
+  background-image:
+    radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.05) 0, transparent 50%),
+    radial-gradient(circle at 82% 12%, rgba(255, 255, 255, 0.04) 0, transparent 55%),
+    radial-gradient(circle at 24% 78%, rgba(255, 255, 255, 0.035) 0, transparent 50%);
 }
 
 button {
@@ -293,9 +299,9 @@ button:focus-visible {
 
 .village-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: var(--space-14);
-  width: min(100%, 36rem);
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: var(--space-8);
+  width: min(100%, 48rem);
   margin-inline: auto;
 }
 
@@ -2929,5 +2935,614 @@ button:focus-visible {
     position: static;
     margin-top: var(--space-16);
     width: 100%;
+  }
+}
+.village-header-button:hover,
+.village-header-button:focus-visible {
+  background: rgb(59 130 246 / 0.2);
+  border-color: rgb(96 165 250 / 0.8);
+}
+
+.village-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+  padding: var(--space-20);
+  border-radius: var(--card-radius);
+  border: 1px solid rgb(56 78 99 / 0.4);
+  background: linear-gradient(165deg, rgb(22 30 40 / 0.92), rgb(14 22 32 / 0.88));
+  box-shadow: 0 25px 45px -30px rgb(0 0 0 / 0.55);
+}
+
+.village-toolbar__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  max-width: 34rem;
+}
+
+.village-toolbar__resources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12);
+}
+
+.village-toolbar__actions {
+  display: flex;
+  gap: var(--space-12);
+  flex-wrap: wrap;
+}
+
+@media (min-width: 1024px) {
+  .village-toolbar {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  .village-toolbar__resources {
+    justify-content: flex-end;
+    flex: 1;
+  }
+  .village-toolbar__actions {
+    align-items: center;
+  }
+}
+
+.village-blueprint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-10) var(--space-16);
+  border-radius: var(--card-radius);
+  border: 1px solid rgb(74 222 128 / 0.45);
+  background: rgb(34 197 94 / 0.12);
+  box-shadow: inset 0 1px 0 rgb(134 239 172 / 0.3);
+}
+
+.village-blueprint__icon {
+  font-size: 1.6rem;
+}
+
+.village-blueprint__label {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(134 239 172);
+}
+
+.village-blueprint__cancel {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: rgb(187 247 208);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.village-blueprint__cancel:hover,
+.village-blueprint__cancel:focus-visible {
+  text-decoration: underline;
+}
+
+.village-view-tab {
+  appearance: none;
+  border: 1px solid transparent;
+  background: rgb(15 23 42 / 0.6);
+  color: rgb(148 163 184);
+  padding: var(--space-10) var(--space-16);
+  border-radius: var(--space-12);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.village-view-tab.is-active {
+  color: rgb(226 232 240);
+  border-color: rgb(96 165 250 / 0.55);
+  background: linear-gradient(165deg, rgb(37 99 235 / 0.25), rgb(14 34 84 / 0.35));
+  box-shadow: inset 0 1px 0 rgb(148 197 255 / 0.3);
+}
+
+.village-view-tab:hover,
+.village-view-tab:focus-visible {
+  color: rgb(226 232 240);
+  border-color: rgb(96 165 250 / 0.4);
+}
+
+.village-views {
+  margin-top: var(--space-20);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+.village-views__tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-12);
+}
+
+.village-view-panel[hidden] {
+  display: none;
+}
+
+.village-catalog {
+  display: grid;
+  gap: var(--space-16);
+}
+
+.village-catalog__group {
+  border: 1px solid rgb(56 78 99 / 0.45);
+  border-radius: var(--card-radius);
+  background: linear-gradient(170deg, rgb(19 31 42 / 0.85), rgb(10 18 28 / 0.8));
+  padding: var(--space-16);
+  box-shadow: 0 24px 48px -32px rgb(0 0 0 / 0.55);
+}
+
+.village-catalog__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 var(--space-12);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 197 255);
+}
+
+.village-catalog__list {
+  display: grid;
+  gap: var(--space-12);
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.village-card {
+  border: 1px solid rgb(51 65 85 / 0.55);
+  border-radius: var(--space-16);
+  padding: var(--space-16);
+  background: linear-gradient(170deg, rgb(20 34 44 / 0.88), rgb(11 19 28 / 0.82));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  box-shadow: inset 0 1px 0 rgb(148 163 184 / 0.08);
+}
+
+.village-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+}
+
+.village-card__icon {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.village-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgb(226 232 240);
+}
+
+.village-card__tag {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.village-card__body {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgb(191 199 210);
+}
+
+.village-card__io {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(147 197 253);
+}
+
+.village-card__io span {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgb(37 99 235 / 0.18);
+  border: 1px solid rgb(37 99 235 / 0.25);
+}
+
+.village-card__footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-12);
+}
+
+.village-card__action {
+  appearance: none;
+  border: 1px solid rgb(96 165 250 / 0.4);
+  background: rgb(37 99 235 / 0.12);
+  color: rgb(191 219 254);
+  font-size: 0.75rem;
+  padding: var(--space-8) var(--space-14);
+  border-radius: var(--space-12);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.village-card__action:hover,
+.village-card__action:focus-visible {
+  background: rgb(37 99 235 / 0.2);
+  border-color: rgb(96 165 250 / 0.65);
+}
+
+.village-map-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+@media (min-width: 1080px) {
+  .village-map-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .village-map-board {
+    flex: 1 1 60%;
+  }
+}
+
+.supply-panel {
+  flex: 1 1 22rem;
+  border-radius: var(--card-radius);
+  border: 1px solid rgb(51 65 85 / 0.5);
+  background: linear-gradient(170deg, rgb(16 26 37 / 0.92), rgb(9 16 24 / 0.88));
+  padding: var(--space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+  box-shadow: 0 24px 48px -30px rgb(0 0 0 / 0.55);
+}
+
+.supply-panel__detail {
+  border-radius: var(--space-16);
+  border: 1px solid rgb(71 85 105 / 0.5);
+  padding: var(--space-16);
+  background: rgb(12 20 28 / 0.8);
+}
+
+.supply-panel__placeholder {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgb(148 163 184);
+}
+
+.supply-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.supply-panel__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+}
+
+.supply-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 0.9rem;
+  background: rgb(30 41 59 / 0.85);
+  border: 1px solid rgb(71 85 105 / 0.6);
+  font-size: 1.5rem;
+}
+
+.supply-panel__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgb(226 232 240);
+}
+
+.supply-panel__meta {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.supply-panel__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgb(191 199 210);
+}
+
+.supply-panel__stats {
+  display: grid;
+  gap: var(--space-8);
+  font-size: 0.8rem;
+  color: rgb(203 213 225);
+}
+
+.supply-panel__stats dt {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 197 255);
+}
+
+.supply-panel__stats dd {
+  margin: 0;
+}
+
+.supply-panel__notes {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgb(148 163 184);
+  font-size: 0.8rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.village-action-button {
+  appearance: none;
+  border-radius: var(--space-12);
+  border: 1px solid rgb(59 130 246 / 0.4);
+  background: rgb(37 99 235 / 0.15);
+  color: rgb(191 219 254);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--space-8) var(--space-16);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.village-action-button--danger {
+  border-color: rgb(248 113 113 / 0.5);
+  background: rgb(248 113 113 / 0.12);
+  color: rgb(254 202 202);
+}
+
+.village-action-button:hover,
+.village-action-button:focus-visible {
+  border-color: rgb(96 165 250 / 0.8);
+  background: rgb(37 99 235 / 0.25);
+}
+
+.village-action-button--danger:hover,
+.village-action-button--danger:focus-visible {
+  border-color: rgb(252 165 165 / 0.85);
+  background: rgb(248 113 113 / 0.25);
+}
+
+.supply-panel__chains {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.supply-panel__heading {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 197 255);
+}
+
+.supply-status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-8);
+}
+
+.supply-status-list__item {
+  padding: var(--space-10) var(--space-12);
+  border-radius: var(--space-12);
+  border-left: 4px solid rgb(148 163 184 / 0.4);
+  background: rgb(15 23 42 / 0.75);
+  display: grid;
+  gap: 2px;
+  font-size: 0.8rem;
+}
+
+.supply-status-list__item[data-status="operational"] {
+  border-left-color: rgb(134 239 172 / 0.7);
+}
+
+.supply-status-list__item[data-status="bottleneck"] {
+  border-left-color: rgb(250 204 21 / 0.7);
+}
+
+.supply-status-list__item[data-status="inactive"] {
+  border-left-color: rgb(252 165 165 / 0.7);
+}
+
+.supply-status-list__item strong {
+  font-weight: 600;
+  color: rgb(226 232 240);
+}
+
+.supply-panel__totals {
+  display: grid;
+  gap: var(--space-12);
+}
+
+.supply-panel__totals-label {
+  display: block;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(148 163 184);
+}
+
+.supply-panel__totals-list {
+  list-style: none;
+  margin: var(--space-6) 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+  color: rgb(203 213 225);
+}
+
+.resource-flow {
+  display: grid;
+  gap: var(--space-12);
+}
+
+.resource-flow__link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-12) var(--space-16);
+  border-radius: var(--space-16);
+  border: 1px solid rgb(56 78 99 / 0.45);
+  background: rgb(15 23 42 / 0.78);
+  box-shadow: inset 0 1px 0 rgb(148 163 184 / 0.08);
+  font-size: 0.85rem;
+}
+
+.resource-flow__link strong {
+  color: rgb(226 232 240);
+}
+
+.resource-flow__arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgb(59 130 246 / 0.2);
+  color: rgb(148 197 255);
+  font-size: 0.9rem;
+}
+
+.resource-flow__meta {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: rgb(148 163 184);
+  text-align: right;
+}
+
+.resource-flow__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgb(148 163 184);
+}
+
+.village-grid__actions {
+  position: absolute;
+  top: var(--space-8);
+  right: var(--space-8);
+  display: inline-flex;
+  gap: var(--space-8);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.village-grid__cell:hover .village-grid__actions,
+.village-grid__cell:focus-within .village-grid__actions {
+  opacity: 1;
+}
+
+.village-grid__action {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  background: rgb(15 23 42 / 0.8);
+  color: rgb(191 219 254);
+  width: 1.8rem;
+  height: 1.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgb(96 165 250 / 0.4);
+}
+
+.village-grid__action:hover,
+.village-grid__action:focus-visible {
+  box-shadow: inset 0 0 0 1px rgb(147 197 253 / 0.8);
+}
+
+.village-grid__cell[data-category="production"] {
+  border-color: rgb(96 165 250 / 0.65);
+}
+
+.village-grid__cell[data-category="housing"] {
+  border-color: rgb(250 204 21 / 0.6);
+}
+
+.village-grid__cell[data-category="storage"] {
+  border-color: rgb(244 165 96 / 0.6);
+}
+
+.village-grid__cell[data-category="transport"] {
+  border-color: rgb(129 199 212 / 0.6);
+}
+
+.village-grid__cell[data-category="support"] {
+  border-color: rgb(134 239 172 / 0.6);
+}
+
+.village-grid__cell.is-blueprint-target {
+  border-style: dashed;
+  border-color: rgb(191 219 254 / 0.75);
+  box-shadow: 0 0 0 1px rgb(37 99 235 / 0.3);
+}
+
+@keyframes villageSpawn {
+  0% {
+    transform: scale(0.7) translateY(12px);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+.village-grid__cell.is-spawned {
+  animation: villageSpawn 0.45s ease;
+}
+
+.village-resource-chip.is-gaining {
+  animation: chipPulse 0.45s ease;
+  box-shadow: 0 0 0 4px rgb(74 222 128 / 0.18);
+  border-color: rgb(134 239 172 / 0.6);
+}
+
+@keyframes chipPulse {
+  0% {
+    transform: scale(1);
+  }
+  30% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -361,20 +361,46 @@
       hidden
     >
       <section class="panel panel--village">
-        <div class="panel-header panel-header--village">
-          <div class="panel-header__title-group">
-            <h2 class="panel-title">Village design</h2>
+        <div class="village-toolbar">
+          <div class="village-toolbar__info">
+            <h2 class="panel-title">Village planner</h2>
             <p class="panel-subtitle">
-              Place buildings on the 5×5 grid to shape your settlement. Bonuses
-              are applied automatically based on terrain and adjacency.
+              Lay out production chains on the 10×10 board, balance logistics and keep
+              houses close to support. Distance matters – efficient routes keep the
+              village thriving.
             </p>
+            <div class="village-blueprint" data-village-blueprint hidden>
+              <span class="village-blueprint__icon" data-village-blueprint-icon>🏗️</span>
+              <div>
+                <p class="village-blueprint__label" data-village-blueprint-label>
+                  Blueprint ready
+                </p>
+                <button
+                  type="button"
+                  class="village-blueprint__cancel"
+                  data-village-blueprint-clear
+                >
+                  Cancel blueprint
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="village-header-controls">
-            <div class="village-resource-bar" aria-live="polite">
+          <div class="village-toolbar__resources" aria-live="polite">
+            <div class="village-resource-bar">
+              <div class="village-resource-chip" data-village-resource-chip>
+                <span class="village-resource-chip__icon">🪙</span>
+                <span class="village-resource-chip__label">Gold</span>
+                <span class="village-resource-chip__value" data-village-resource="gold">0</span>
+              </div>
               <div class="village-resource-chip" data-village-resource-chip>
                 <span class="village-resource-chip__icon">🪵</span>
                 <span class="village-resource-chip__label">Wood</span>
                 <span class="village-resource-chip__value" data-village-resource="wood">0</span>
+              </div>
+              <div class="village-resource-chip" data-village-resource-chip>
+                <span class="village-resource-chip__icon">🧱</span>
+                <span class="village-resource-chip__label">Planks</span>
+                <span class="village-resource-chip__value" data-village-resource="planks">0</span>
               </div>
               <div class="village-resource-chip" data-village-resource-chip>
                 <span class="village-resource-chip__icon">🪨</span>
@@ -382,14 +408,14 @@
                 <span class="village-resource-chip__value" data-village-resource="stone">0</span>
               </div>
               <div class="village-resource-chip" data-village-resource-chip>
-                <span class="village-resource-chip__icon">🍖</span>
-                <span class="village-resource-chip__label">Food</span>
-                <span class="village-resource-chip__value" data-village-resource="food">0</span>
+                <span class="village-resource-chip__icon">🥢</span>
+                <span class="village-resource-chip__label">Sticks</span>
+                <span class="village-resource-chip__value" data-village-resource="sticks">0</span>
               </div>
               <div class="village-resource-chip" data-village-resource-chip>
-                <span class="village-resource-chip__icon">🪙</span>
-                <span class="village-resource-chip__label">Gold</span>
-                <span class="village-resource-chip__value" data-village-resource="gold">0</span>
+                <span class="village-resource-chip__icon">🛠️</span>
+                <span class="village-resource-chip__label">Tools</span>
+                <span class="village-resource-chip__value" data-village-resource="tools">0</span>
               </div>
               <div class="village-resource-chip" data-village-resource-chip>
                 <span class="village-resource-chip__icon">👥</span>
@@ -397,92 +423,175 @@
                 <span class="village-resource-chip__value" data-village-resource="villagers">0/0</span>
               </div>
             </div>
-            <div class="village-header-actions">
-              <button
-                type="button"
-                class="village-header-button"
-                data-village-save
-              >
-                Save design
-              </button>
-              <button
-                type="button"
-                class="village-header-button"
-                data-village-load
-              >
-                Load design
-              </button>
-            </div>
+          </div>
+          <div class="village-toolbar__actions">
+            <button type="button" class="village-header-button" data-village-save>
+              Save design
+            </button>
+            <button type="button" class="village-header-button" data-village-load>
+              Load design
+            </button>
           </div>
         </div>
         <div class="village-status" data-village-status role="status" aria-live="polite"></div>
-        <div class="village-design">
-          <div class="village-grid-wrapper">
-            <div
-              class="village-grid"
-              role="grid"
-              aria-label="Village terrain"
-              data-village-grid
-            ></div>
-            <div class="village-build-menu" data-village-build-menu hidden>
-              <div class="village-build-menu__panel">
-                <header class="village-build-menu__header">
-                  <h3 class="village-build-menu__title">Construct building</h3>
-                  <button
-                    type="button"
-                    class="village-build-menu__close"
-                    data-village-build-close
-                    aria-label="Close build menu"
-                  >
-                    ×
-                  </button>
-                </header>
-                <div
-                  class="village-build-menu__body"
-                  data-village-build-list
-                ></div>
-              </div>
-            </div>
+        <div class="village-views">
+          <div class="village-views__tabs" role="tablist" aria-label="Village views">
+            <button
+              id="village-tab-buildings"
+              class="village-view-tab is-active"
+              type="button"
+              role="tab"
+              aria-selected="true"
+              data-village-view-tab="buildings"
+              aria-controls="village-view-buildings"
+            >
+              Buildings
+            </button>
+            <button
+              id="village-tab-map"
+              class="village-view-tab"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              data-village-view-tab="map"
+              aria-controls="village-view-map"
+            >
+              Village map
+            </button>
+            <button
+              id="village-tab-flow"
+              class="village-view-tab"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              data-village-view-tab="flow"
+              aria-controls="village-view-flow"
+            >
+              Resource flow
+            </button>
           </div>
-          <aside class="village-sidebar" data-village-sidebar aria-live="polite">
-            <div class="village-sidebar__placeholder" data-village-sidebar-empty>
-              Select a cell to inspect terrain bonuses or manage a building.
-            </div>
-            <div class="village-sidebar__content" data-village-sidebar-content hidden>
-              <header class="village-sidebar__header">
-                <span class="village-sidebar__icon" data-village-detail-icon>🏡</span>
-                <div>
-                  <h3 class="village-sidebar__title" data-village-detail-name>
-                    Structure
-                  </h3>
-                  <p class="village-sidebar__meta" data-village-detail-meta></p>
+          <div class="village-views__panels">
+            <section
+              id="village-view-buildings"
+              class="village-view-panel is-active"
+              data-village-view-panel="buildings"
+              role="tabpanel"
+              aria-labelledby="village-tab-buildings"
+            >
+              <div class="village-catalog" data-village-building-list></div>
+              <p class="village-catalog__empty" data-village-catalog-empty hidden>
+                Catalog unavailable right now.
+              </p>
+            </section>
+            <section
+              id="village-view-map"
+              class="village-view-panel"
+              data-village-view-panel="map"
+              role="tabpanel"
+              aria-labelledby="village-tab-map"
+              hidden
+            >
+              <div class="village-map-layout">
+                <div class="village-map-board">
+                  <div id="village-map" class="village-map">
+                    <div class="village-grid-wrapper">
+                      <div
+                        id="village-grid"
+                        class="village-grid"
+                        role="grid"
+                        aria-label="Village terrain"
+                        data-village-grid
+                      ></div>
+                    </div>
+                    <svg id="village-overlay" class="village-overlay" aria-hidden="true"></svg>
+                  </div>
                 </div>
-              </header>
-              <p class="village-sidebar__description" data-village-detail-description></p>
-              <dl class="village-sidebar__stats">
-                <div class="village-sidebar__stat">
-                  <dt>Production</dt>
-                  <dd data-village-detail-production>—</dd>
-                </div>
-                <div class="village-sidebar__stat">
-                  <dt>Efficiency</dt>
-                  <dd data-village-detail-efficiency>100%</dd>
-                </div>
-                <div class="village-sidebar__stat">
-                  <dt>Transport</dt>
-                  <dd data-village-detail-transport>+0%</dd>
-                </div>
-              </dl>
-              <ul class="village-sidebar__notes" data-village-detail-notes></ul>
-              <button
-                type="button"
-                class="village-sidebar__demolish"
-                data-village-demolish
-              >
-                Demolish building
-              </button>
-            </div>
-          </aside>
+                <aside class="supply-panel" data-village-sidebar aria-live="polite">
+                  <div class="supply-panel__detail" data-village-detail>
+                    <div class="supply-panel__placeholder" data-village-sidebar-empty>
+                      Select a tile to inspect terrain bonuses or manage a building.
+                    </div>
+                    <div class="supply-panel__content" data-village-sidebar-content hidden>
+                      <header class="supply-panel__header">
+                        <span class="supply-panel__icon" data-village-detail-icon>🏡</span>
+                        <div>
+                          <h3 class="supply-panel__title" data-village-detail-name>Structure</h3>
+                          <p class="supply-panel__meta" data-village-detail-meta></p>
+                        </div>
+                      </header>
+                      <p class="supply-panel__description" data-village-detail-description></p>
+                      <dl class="supply-panel__stats">
+                        <div>
+                          <dt>Production</dt>
+                          <dd data-village-detail-production>—</dd>
+                        </div>
+                        <div>
+                          <dt>Inputs</dt>
+                          <dd data-village-detail-inputs>—</dd>
+                        </div>
+                        <div>
+                          <dt>Efficiency</dt>
+                          <dd data-village-detail-efficiency>100%</dd>
+                        </div>
+                        <div>
+                          <dt>Transport</dt>
+                          <dd data-village-detail-transport>+0%</dd>
+                        </div>
+                        <div>
+                          <dt>Workers</dt>
+                          <dd data-village-detail-workers>0</dd>
+                        </div>
+                      </dl>
+                      <ul class="supply-panel__notes" data-village-detail-notes></ul>
+                      <div class="supply-panel__actions">
+                        <button
+                          type="button"
+                          class="village-action-button"
+                          data-village-action="upgrade"
+                        >
+                          Upgrade
+                        </button>
+                        <button
+                          type="button"
+                          class="village-action-button village-action-button--danger"
+                          data-village-action="demolish"
+                        >
+                          Demolish
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="supply-panel__chains">
+                    <h3 class="supply-panel__heading">Supply status</h3>
+                    <ul class="supply-status-list" data-supply-status-list></ul>
+                    <div class="supply-panel__totals">
+                      <div>
+                        <span class="supply-panel__totals-label">Production/min</span>
+                        <ul class="supply-panel__totals-list" data-supply-total-production></ul>
+                      </div>
+                      <div>
+                        <span class="supply-panel__totals-label">Consumption/min</span>
+                        <ul class="supply-panel__totals-list" data-supply-total-consumption></ul>
+                      </div>
+                    </div>
+                  </div>
+                </aside>
+              </div>
+            </section>
+            <section
+              id="village-view-flow"
+              class="village-view-panel"
+              data-village-view-panel="flow"
+              role="tabpanel"
+              aria-labelledby="village-tab-flow"
+              hidden
+            >
+              <div class="resource-flow" data-resource-flow></div>
+              <p class="resource-flow__empty" data-resource-flow-empty hidden>
+                Build production chains to visualise their routes.
+              </p>
+            </section>
+          </div>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- extend the village design backend with distance-aware efficiency, supply overviews, upgrades, and sandbox-aware build costs
- expose new upgrade API wiring so the front end can manage tiering directly from the redesigned village planner
- rebuild the village interface with the catalog/map/flow tabs, resource chips, supply sidebar, and blueprint-driven build interactions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e528ff7fbc8332896b13c7914db382